### PR TITLE
Feat: 이메일 유효성 검증 및 Resend SMTP 연동 완료

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@supabase/supabase-js": "^2.50.1",
+        "axios": "^1.10.0",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
@@ -1870,7 +1871,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -1881,6 +1881,17 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2220,7 +2231,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2507,7 +2517,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2703,7 +2712,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2977,7 +2985,6 @@
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2985,7 +2992,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -2999,7 +3005,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
       "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3436,7 +3441,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4545,6 +4549,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.13.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,11 +7,12 @@
     "build": "tsc",
     "start": "node dist/server.js",
     "test:api": "NODE_ENV=test mocha -r ts-node/register --extensions ts --recursive \"test/**/*.api.test.ts\"",
-    "test:unit": "NODE_ENV=test mocha -r ts-node/register --extensions ts --recursive \"test/**/*.scheduler.test.ts\"" 
+    "test:unit": "NODE_ENV=test mocha -r ts-node/register --extensions ts --recursive \"test/**/*.scheduler.test.ts\""
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "@supabase/supabase-js": "^2.50.1",
+    "axios": "^1.10.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -40,15 +40,14 @@ router.post('/signup', async (req: Request<{}, {}, SignupRequest>, res: Response
     // 이메일 유효성 검증 (Mailboxlayer)
     const mailboxlayerApiKeys = [
       process.env.MAILBOXLAYER_API_KEY1,
-      process.env.MAILBOXLAYER_API_KEY2
+      process.env.MAILBOXLAYER_API_KEY2,
+      process.env.MAILBOXLAYER_API_KEY3
     ];
     let mailboxRes, mailboxError;
     for (let i = 0; i < mailboxlayerApiKeys.length; i++) {
       try {
-        const mailboxlayerUrl = `https://api.apilayer.com/email_verification/check?email=${encodeURIComponent(email.trim())}`;
-        mailboxRes = await axios.get(mailboxlayerUrl, {
-          headers: { 'apikey': mailboxlayerApiKeys[i] }
-        });
+        const mailboxlayerUrl = `http://apilayer.net/api/check?access_key=${mailboxlayerApiKeys[i]}&email=${encodeURIComponent(email.trim())}&smtp=1&format=1`;
+        mailboxRes = await axios.get(mailboxlayerUrl);
         mailboxError = null;
         break; // 성공하면 반복 종료
       } catch (err) {
@@ -781,6 +780,86 @@ router.get('/confirm-email', async (req: Request, res: Response) => {
     const dynamicConfig = getDynamicConfig(req);
     console.error('이메일 인증 확인 오류:', error);
     res.redirect(`${dynamicConfig.FRONTEND_URL}/login?error=confirmation_failed`);
+  }
+});
+
+// 이메일 유효성 검증 (MailboxLayer API 사용)
+router.post('/validate-email', async (req: Request, res: Response<ApiResponse>) => {
+  try {
+    const { email } = req.body;
+
+    if (!email) {
+      return res.status(400).json({
+        success: false,
+        error: '이메일 주소를 입력해주세요.'
+      });
+    }
+
+    // 이메일 형식 기본 검증
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email.trim())) {
+      return res.status(400).json({
+        success: false,
+        data: { valid: false, message: '올바른 이메일 형식이 아닙니다.' }
+      });
+    }
+
+    // MailboxLayer API를 사용한 이메일 유효성 검증
+    const mailboxlayerApiKeys = [
+      process.env.MAILBOXLAYER_API_KEY1,
+      process.env.MAILBOXLAYER_API_KEY2,
+      process.env.MAILBOXLAYER_API_KEY3
+    ];
+    
+    let mailboxRes, mailboxError;
+    for (let i = 0; i < mailboxlayerApiKeys.length; i++) {
+      if (!mailboxlayerApiKeys[i]) continue;
+      
+      console.log(`API 키 ${i + 1} 사용:`, mailboxlayerApiKeys[i]);
+      
+      try {
+        const mailboxlayerUrl = `http://apilayer.net/api/check?access_key=${mailboxlayerApiKeys[i]}&email=${encodeURIComponent(email.trim())}&smtp=1&format=1`;
+        mailboxRes = await axios.get(mailboxlayerUrl);
+        mailboxError = null;
+        break; // 성공하면 반복 종료
+      } catch (err) {
+        mailboxError = err;
+        console.log(`API 키 ${i + 1} 실패:`, err);
+        // 다음 키로 재시도
+      }
+    }
+
+    if (mailboxError || !mailboxRes) {
+      console.error('MailboxLayer API 오류:', mailboxError);
+      return res.status(500).json({
+        success: false,
+        error: '이메일 유효성 검증 중 오류가 발생했습니다.'
+      });
+    }
+
+    const { format_valid, smtp_check, mx_found } = mailboxRes.data;
+    
+    if (!format_valid || !smtp_check || !mx_found) {
+      return res.status(200).json({
+        success: true,
+        data: { 
+          valid: false, 
+          message: '유효하지 않은 이메일 주소입니다. 올바른 이메일을 입력해주세요.' 
+        }
+      });
+    }
+
+    res.json({
+      success: true,
+      data: { valid: true }
+    });
+
+  } catch (error) {
+    console.error('이메일 유효성 검증 오류:', error);
+    res.status(500).json({
+      success: false,
+      error: '이메일 유효성 검증 중 오류가 발생했습니다.'
+    });
   }
 });
 

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -114,6 +114,14 @@ class ApiClient {
       method: 'GET',
     });
   }
+
+  // 이메일 유효성 검증 (MailboxLayer API 사용)
+  async validateEmail(email: string): Promise<ApiResponse<{ valid: boolean; message?: string }>> {
+    return this.request<{ valid: boolean; message?: string }>('/auth/validate-email', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    });
+  }
 }
 
 export const apiClient = new ApiClient(API_BASE_URL); 


### PR DESCRIPTION
- MailboxLayer API를 사용한 이메일 유효성 검증 기능 추가
  - 3개의 API 키를 순차적으로 시도하여 안정성 향상
  - 이메일 형식, SMTP, MX 레코드 검증
  - 프론트엔드에서 회원가입 전 이메일 검증 수행

- Supabase Auth를 통한 회원가입 기능 구현
  - 이메일 인증 기반 회원가입
  - 사용자 메타데이터에 이름, 주민번호 저장
  - 이메일 인증 완료 후 사용자 정보 DB 저장

- Resend SMTP 연동 완료
  - 도메인 구매 후 Resend SMTP 설정 완료
  - Supabase 이메일 서비스 대신 Resend 사용
  - 이메일 전송 안정성 및 도달률 향상

- 프론트엔드 회원가입 페이지 개선
  - 실시간 이메일 유효성 검증
  - 주민번호 7자리 형식 검증
  - 비밀번호 확인 기능
  - 에러 처리 및 사용자 피드백 개선

- 백엔드 API 엔드포인트 추가
  - /auth/validate-email: 이메일 유효성 검증
  - /auth/signup: 회원가입 처리
  - /auth/confirm-email: 이메일 인증 확인

- 환경 변수 설정
  - MAILBOXLAYER_API_KEY1,2,3 추가
  - Supabase 설정 완료
  - Resend SMTP 설정 완료