### PR TITLE
Feat: 공연 찜하기 기능 API 구현

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -14,6 +14,7 @@ import seatsRouter from './seats/seats.controller';
 import ticketsRouter from './tickets/tickets.controller';
 import authRouter from './auth/auth.controller';
 import chatbotRouter from './chatbot/chatbot.controller';
+import userFavoritesRouter from './user_favorites/user_favorites.controller';
 
 
 // NODE_ENV가 test 가 아닐 때만 스케줄러 구동
@@ -61,6 +62,15 @@ app.use('/seats', seatsRouter);
 //    - /tickets/cancel (티켓 취소 / on-chain + DB)
 //    - /tickets/... 기타 엔드포인트
 app.use('/tickets', ticketsRouter);
+
+// ■ 찜하기 관련 라우트
+//    - POST /user-favorites (찜하기 추가)
+//    - DELETE /user-favorites/:concertId (찜하기 삭제)
+//    - GET /user-favorites (내가 찜한 공연 목록)
+//    - GET /user-favorites/check/:concertId (찜하기 상태 확인)
+//    - POST /user-favorites/toggle/:concertId (찜하기 토글)
+app.use('/user-favorites', userFavoritesRouter);
+
 app.use('/chatbot', chatbotRouter);
 
 export default app; 

--- a/backend/src/user_favorites/README.md
+++ b/backend/src/user_favorites/README.md
@@ -1,0 +1,229 @@
+# 찜하기 API 문서
+
+## 개요
+사용자가 공연을 찜하고, 마이페이지에서 찜한 공연 목록을 조회할 수 있는 API입니다.
+
+## 인증
+모든 엔드포인트는 JWT 토큰 인증이 필요합니다.
+```
+Authorization: Bearer <your-jwt-token>
+```
+
+## API 엔드포인트
+
+### 1. 찜하기 추가
+**POST** `/user-favorites`
+
+공연을 찜하기에 추가합니다.
+
+**Request Body:**
+```json
+{
+  "concert_id": "uuid-string"
+}
+```
+
+**Response (201):**
+```json
+{
+  "success": true,
+  "data": {
+    "id": "uuid",
+    "user_id": "uuid",
+    "concert_id": "uuid",
+    "created_at": "2024-01-01T00:00:00Z"
+  },
+  "message": "공연을 찜했습니다."
+}
+```
+
+**Error (400):**
+```json
+{
+  "success": false,
+  "error": "이미 찜한 공연입니다."
+}
+```
+
+### 2. 찜하기 삭제
+**DELETE** `/user-favorites/:concertId`
+
+찜하기에서 공연을 삭제합니다.
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "message": "찜하기가 삭제되었습니다."
+}
+```
+
+### 3. 내가 찜한 공연 목록 조회
+**GET** `/user-favorites`
+
+현재 사용자가 찜한 모든 공연 목록을 조회합니다.
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "uuid",
+      "user_id": "uuid",
+      "concert_id": "uuid",
+      "created_at": "2024-01-01T00:00:00Z",
+      "concert": {
+        "id": "uuid",
+        "title": "공연 제목",
+        "date": "2024-01-01T00:00:00Z",
+        "poster_url": "https://example.com/poster.jpg",
+        "organizer": "주최사",
+        "main_performer": "주연",
+        "venue_name": "공연장 이름",
+        "venue_address": "공연장 주소"
+      }
+    }
+  ],
+  "message": "찜한 공연 목록을 조회했습니다."
+}
+```
+
+### 4. 찜하기 상태 확인
+**GET** `/user-favorites/check/:concertId`
+
+특정 공연의 찜하기 상태를 확인합니다.
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "data": {
+    "isFavorite": true
+  },
+  "message": "찜하기 상태를 확인했습니다."
+}
+```
+
+### 5. 찜하기 토글
+**POST** `/user-favorites/toggle/:concertId`
+
+찜하기 상태를 토글합니다. (찜한 상태면 삭제, 안 찜한 상태면 추가)
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "data": {
+    "isFavorite": true
+  },
+  "message": "공연을 찜했습니다."
+}
+```
+
+## 사용 예시
+
+### JavaScript/TypeScript
+```javascript
+// 찜하기 추가
+const addToFavorites = async (concertId) => {
+  const response = await fetch('/user-favorites', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`
+    },
+    body: JSON.stringify({ concert_id: concertId })
+  });
+  return response.json();
+};
+
+// 찜한 공연 목록 조회
+const getFavorites = async () => {
+  const response = await fetch('/user-favorites', {
+    headers: {
+      'Authorization': `Bearer ${token}`
+    }
+  });
+  return response.json();
+};
+
+// 찜하기 토글
+const toggleFavorite = async (concertId) => {
+  const response = await fetch(`/user-favorites/toggle/${concertId}`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`
+    }
+  });
+  return response.json();
+};
+```
+
+### React Hook 예시
+```javascript
+import { useState, useEffect } from 'react';
+
+const useFavorites = () => {
+  const [favorites, setFavorites] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchFavorites = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('/user-favorites', {
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      const data = await response.json();
+      if (data.success) {
+        setFavorites(data.data);
+      }
+    } catch (error) {
+      console.error('찜한 공연 조회 실패:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleFavorite = async (concertId) => {
+    try {
+      const response = await fetch(`/user-favorites/toggle/${concertId}`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      const data = await response.json();
+      if (data.success) {
+        // 목록 새로고침
+        fetchFavorites();
+      }
+    } catch (error) {
+      console.error('찜하기 토글 실패:', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchFavorites();
+  }, []);
+
+  return { favorites, loading, toggleFavorite, refetch: fetchFavorites };
+};
+```
+
+## 에러 처리
+
+모든 API는 다음과 같은 에러 응답을 반환할 수 있습니다:
+
+- **400 Bad Request**: 잘못된 요청 (이미 찜한 공연, 존재하지 않는 공연 등)
+- **401 Unauthorized**: 인증 토큰이 없거나 유효하지 않음
+- **500 Internal Server Error**: 서버 내부 오류
+
+## 주의사항
+
+1. 모든 요청에는 유효한 JWT 토큰이 필요합니다.
+2. 사용자는 본인의 찜하기만 조회/수정할 수 있습니다.
+3. 존재하지 않는 공연 ID로 요청하면 에러가 발생합니다.
+4. 이미 찜한 공연을 다시 찜하려고 하면 에러가 발생합니다. 

--- a/backend/src/user_favorites/user_favorites.controller.ts
+++ b/backend/src/user_favorites/user_favorites.controller.ts
@@ -1,0 +1,170 @@
+import { Router, Request, Response } from 'express';
+import { authenticateToken } from '../auth/auth.middleware';
+import { ApiResponse } from '../types/auth';
+import { CreateUserFavoriteRequest } from './user_favorites.model';
+import { 
+  addToFavorites, 
+  removeFromFavorites, 
+  getUserFavorites, 
+  checkIsFavorite 
+} from './user_favorites.service';
+
+const router = Router();
+
+// 모든 엔드포인트에 인증 미들웨어 적용
+router.use(authenticateToken);
+
+// 찜하기 추가
+router.post('/', async (req: Request<{}, {}, CreateUserFavoriteRequest>, res: Response<ApiResponse>) => {
+  try {
+    const { concert_id } = req.body;
+    const userId = req.user!.id;
+
+    if (!concert_id) {
+      return res.status(400).json({
+        success: false,
+        error: '공연 ID가 필요합니다.'
+      });
+    }
+
+    const favorite = await addToFavorites(userId, concert_id);
+
+    res.status(201).json({
+      success: true,
+      data: favorite,
+      message: '공연을 찜했습니다.'
+    });
+
+  } catch (error) {
+    console.error('찜하기 추가 오류:', error);
+    res.status(400).json({
+      success: false,
+      error: error instanceof Error ? error.message : '찜하기 추가 중 오류가 발생했습니다.'
+    });
+  }
+});
+
+// 찜하기 삭제
+router.delete('/:concertId', async (req: Request, res: Response<ApiResponse>) => {
+  try {
+    const { concertId } = req.params;
+    const userId = req.user!.id;
+
+    if (!concertId) {
+      return res.status(400).json({
+        success: false,
+        error: '공연 ID가 필요합니다.'
+      });
+    }
+
+    await removeFromFavorites(userId, concertId);
+
+    res.json({
+      success: true,
+      message: '찜하기가 삭제되었습니다.'
+    });
+
+  } catch (error) {
+    console.error('찜하기 삭제 오류:', error);
+    res.status(400).json({
+      success: false,
+      error: error instanceof Error ? error.message : '찜하기 삭제 중 오류가 발생했습니다.'
+    });
+  }
+});
+
+// 내가 찜한 공연 목록 조회
+router.get('/', async (req: Request, res: Response<ApiResponse>) => {
+  try {
+    const userId = req.user!.id;
+    const favorites = await getUserFavorites(userId);
+
+    res.json({
+      success: true,
+      data: favorites,
+      message: '찜한 공연 목록을 조회했습니다.'
+    });
+
+  } catch (error) {
+    console.error('찜한 공연 조회 오류:', error);
+    res.status(500).json({
+      success: false,
+      error: error instanceof Error ? error.message : '찜한 공연 조회 중 오류가 발생했습니다.'
+    });
+  }
+});
+
+// 특정 공연 찜하기 상태 확인
+router.get('/check/:concertId', async (req: Request, res: Response<ApiResponse>) => {
+  try {
+    const { concertId } = req.params;
+    const userId = req.user!.id;
+
+    if (!concertId) {
+      return res.status(400).json({
+        success: false,
+        error: '공연 ID가 필요합니다.'
+      });
+    }
+
+    const isFavorite = await checkIsFavorite(userId, concertId);
+
+    res.json({
+      success: true,
+      data: { isFavorite },
+      message: '찜하기 상태를 확인했습니다.'
+    });
+
+  } catch (error) {
+    console.error('찜하기 상태 확인 오류:', error);
+    res.status(500).json({
+      success: false,
+      error: error instanceof Error ? error.message : '찜하기 상태 확인 중 오류가 발생했습니다.'
+    });
+  }
+});
+
+// 찜하기 토글 (추가/삭제)
+router.post('/toggle/:concertId', async (req: Request, res: Response<ApiResponse>) => {
+  try {
+    const { concertId } = req.params;
+    const userId = req.user!.id;
+
+    if (!concertId) {
+      return res.status(400).json({
+        success: false,
+        error: '공연 ID가 필요합니다.'
+      });
+    }
+
+    // 현재 찜하기 상태 확인
+    const isFavorite = await checkIsFavorite(userId, concertId);
+
+    if (isFavorite) {
+      // 이미 찜한 상태면 삭제
+      await removeFromFavorites(userId, concertId);
+      res.json({
+        success: true,
+        data: { isFavorite: false },
+        message: '찜하기가 삭제되었습니다.'
+      });
+    } else {
+      // 찜하지 않은 상태면 추가
+      await addToFavorites(userId, concertId);
+      res.json({
+        success: true,
+        data: { isFavorite: true },
+        message: '공연을 찜했습니다.'
+      });
+    }
+
+  } catch (error) {
+    console.error('찜하기 토글 오류:', error);
+    res.status(400).json({
+      success: false,
+      error: error instanceof Error ? error.message : '찜하기 토글 중 오류가 발생했습니다.'
+    });
+  }
+});
+
+export default router; 

--- a/backend/src/user_favorites/user_favorites.model.ts
+++ b/backend/src/user_favorites/user_favorites.model.ts
@@ -1,0 +1,23 @@
+export interface UserFavorite {
+  id: string;
+  user_id: string;
+  concert_id: string;
+  created_at: string;
+}
+
+export interface CreateUserFavoriteRequest {
+  concert_id: string;
+}
+
+export interface UserFavoriteWithConcert extends UserFavorite {
+  concert: {
+    id: string;
+    title: string;
+    date: string;
+    poster_url?: string;
+    organizer: string;
+    main_performer: string;
+    venue_name?: string;
+    venue_address?: string;
+  };
+} 

--- a/backend/src/user_favorites/user_favorites.service.ts
+++ b/backend/src/user_favorites/user_favorites.service.ts
@@ -1,0 +1,144 @@
+import { supabase } from '../lib/supabaseClient';
+import { UserFavorite, CreateUserFavoriteRequest, UserFavoriteWithConcert } from './user_favorites.model';
+
+export const addToFavorites = async (userId: string, concertId: string): Promise<UserFavorite> => {
+  // 이미 찜한 공연인지 확인
+  const { data: existingFavorite, error: checkError } = await supabase
+    .from('user_favorites')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('concert_id', concertId)
+    .maybeSingle();
+
+  if (checkError) {
+    throw new Error(`찜하기 확인 중 오류가 발생했습니다: ${checkError.message}`);
+  }
+
+  if (existingFavorite) {
+    throw new Error('이미 찜한 공연입니다.');
+  }
+
+  // 공연이 존재하는지 확인
+  const { data: concert, error: concertError } = await supabase
+    .from('concerts')
+    .select('id')
+    .eq('id', concertId)
+    .maybeSingle();
+
+  if (concertError) {
+    throw new Error(`공연 정보 확인 중 오류가 발생했습니다: ${concertError.message}`);
+  }
+
+  if (!concert) {
+    throw new Error('존재하지 않는 공연입니다.');
+  }
+
+  // 찜하기 추가
+  const { data: newFavorite, error: insertError } = await supabase
+    .from('user_favorites')
+    .insert({
+      user_id: userId,
+      concert_id: concertId
+    })
+    .select()
+    .single();
+
+  if (insertError) {
+    throw new Error(`찜하기 추가 중 오류가 발생했습니다: ${insertError.message}`);
+  }
+
+  return newFavorite;
+};
+
+export const removeFromFavorites = async (userId: string, concertId: string): Promise<void> => {
+  const { error } = await supabase
+    .from('user_favorites')
+    .delete()
+    .eq('user_id', userId)
+    .eq('concert_id', concertId);
+
+  if (error) {
+    throw new Error(`찜하기 삭제 중 오류가 발생했습니다: ${error.message}`);
+  }
+};
+
+export const getUserFavorites = async (userId: string): Promise<UserFavoriteWithConcert[]> => {
+  const { data: favorites, error } = await supabase
+    .from('user_favorites')
+    .select(`
+      id,
+      user_id,
+      concert_id,
+      created_at,
+      concerts!inner (
+        id,
+        title,
+        date,
+        poster_url,
+        organizer,
+        main_performer,
+        venue_id
+      )
+    `)
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(`찜한 공연 조회 중 오류가 발생했습니다: ${error.message}`);
+  }
+
+  // 장소 정보도 함께 가져오기
+  const favoritesWithVenue = await Promise.all(
+    favorites.map(async (favorite) => {
+      let venueName = null;
+      let venueAddress = null;
+
+      if (favorite.concerts.venue_id) {
+        const { data: venue } = await supabase
+          .from('venues')
+          .select('name, address')
+          .eq('id', favorite.concerts.venue_id)
+          .single();
+
+        if (venue) {
+          venueName = venue.name;
+          venueAddress = venue.address;
+        }
+      }
+
+      return {
+        id: favorite.id,
+        user_id: favorite.user_id,
+        concert_id: favorite.concert_id,
+        created_at: favorite.created_at,
+        concert: {
+          id: favorite.concerts.id,
+          title: favorite.concerts.title,
+          date: favorite.concerts.date,
+          poster_url: favorite.concerts.poster_url,
+          organizer: favorite.concerts.organizer,
+          main_performer: favorite.concerts.main_performer,
+          venue_name: venueName,
+          venue_address: venueAddress
+        }
+      };
+    })
+  );
+
+  return favoritesWithVenue;
+};
+
+export const checkIsFavorite = async (userId: string, concertId: string): Promise<boolean> => {
+  const { data, error } = await supabase
+    .from('user_favorites')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('concert_id', concertId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`찜하기 상태 확인 중 오류가 발생했습니다: ${error.message}`);
+  }
+
+  return !!data;
+}; 


### PR DESCRIPTION
- POST /user-favorites: 찜하기 추가
- DELETE /user-favorites/:concertId: 찜하기 삭제
- GET /user-favorites: 내가 찜한 공연 목록 조회
- GET /user-favorites/check/:concertId: 찜하기 상태 확인
- POST /user-favorites/toggle/:concertId: 찜하기 토글

- JWT 토큰 인증 필수
- RLS 정책으로 보안 강화
- 중복 찜하기 방지
- 공연 정보와 장소 정보 포함 응답
- 상세한 에러 처리 및 API 문서 제공