### PR TITLE
Fix: 얼굴 등록 API 테스트 모드 개선

### DIFF
--- a/ai-server/services/face_service.py
+++ b/ai-server/services/face_service.py
@@ -1,18 +1,32 @@
 import uuid
+import os
 from fastapi import UploadFile, HTTPException
 from utils.io_utils import extract_embedding_from_video, extract_embedding_from_image
 from utils.similarity import cosine_similarity
 from config import supabase, THRESHOLD
 from postgrest.exceptions import APIError
 
-async def register_user_face_db(user_id: str, file: UploadFile, concert_id: str = None):
-    # ✅ UUID 형식 검증
+def validate_uuid_or_test_id(user_id: str) -> str:
+    """UUID 검증 또는 테스트용 ID 허용"""
+    # 테스트용 ID는 항상 허용
+    if user_id in ['test-embedding-only', 'test-user', 'demo-user']:
+        return user_id
+    
+    # 실제 UUID 검증
     try:
-        user_id = str(uuid.UUID(user_id))
+        return str(uuid.UUID(user_id))
     except ValueError:
         raise HTTPException(status_code=400, detail="❌ user_id가 올바른 UUID 형식이 아닙니다.")
 
-    if concert_id is not None:
+def is_test_id(user_id: str) -> bool:
+    """테스트용 ID인지 확인"""
+    return user_id in ['test-embedding-only', 'test-user', 'demo-user']
+
+async def register_user_face_db(user_id: str, file: UploadFile, concert_id: str = None):
+    # ✅ UUID 형식 검증 (테스트용 ID 허용)
+    user_id = validate_uuid_or_test_id(user_id)
+
+    if concert_id is not None and not is_test_id(user_id):
         try:
             concert_id = str(uuid.UUID(concert_id))
         except ValueError:
@@ -23,6 +37,16 @@ async def register_user_face_db(user_id: str, file: UploadFile, concert_id: str 
     if embedding is None:
         raise HTTPException(status_code=400, detail="❌ 얼굴을 감지하지 못했습니다.")
 
+    # 테스트용 ID인 경우 DB 저장 건너뛰고 임베딩값만 반환
+    if is_test_id(user_id):
+        return {
+            "message": f"✅ 테스트 사용자 {user_id} 얼굴 등록 완료 (DB 저장 없음)",
+            "embedding_shape": f"{len(embedding)} 차원",
+            "embedding_sample": embedding[:5].tolist(),  # 처음 5개 값만 샘플로 반환
+            "test_mode": True
+        }
+
+    # 실제 사용자의 경우 DB에 저장
     data = {
         "id": str(uuid.uuid4()),
         "user_id": user_id,
@@ -39,6 +63,18 @@ async def register_user_face_db(user_id: str, file: UploadFile, concert_id: str 
 
 
 async def verify_user_identity(user_id: str, live: UploadFile, idcard: UploadFile):
+    # UUID 검증 (테스트용 ID 허용)
+    user_id = validate_uuid_or_test_id(user_id)
+    
+    # 테스트용 ID인 경우 더미 데이터로 인증 성공 반환
+    if is_test_id(user_id):
+        return {
+            "authenticated": True,
+            "similarity_face": 0.95,
+            "similarity_id": 0.92,
+            "test_mode": True
+        }
+    
     # DB에서 등록된 임베딩 불러오기
     response = supabase.table("face_embeddings").select("embedding").eq("user_id", user_id).execute()
     if response.get("error") or not response.data:


### PR DESCRIPTION
- 테스트용 ID (test-embedding-only) 사용 시 DB 저장 건너뛰기
- 임베딩 차원 및 샘플값 반환으로 테스트 용이성 향상
- 테스트 모드에서 더미 인증 데이터 제공
- 얼굴 등록 프로세스: 카메라시작 → 녹화시작 → 녹화중지 → 얼굴등록
- 카메라 종료 시 녹화 데이터 사라짐 주의사항 추가