### PR TITLE
Refactor: 취소정책 모듈 구조 개선 및 챗봇 텍스트 매칭 개선 

### DIFF
--- a/backend/src/cancellation_policies/cancellation_policies.model.ts
+++ b/backend/src/cancellation_policies/cancellation_policies.model.ts
@@ -1,6 +1,5 @@
 export interface CancellationPolicy {
   id: string;
-  concert_id: string;
   period_desc: string;
   fee_desc: string;
 } 

--- a/backend/src/cancellation_policies/cancellation_policies.service.ts
+++ b/backend/src/cancellation_policies/cancellation_policies.service.ts
@@ -1,0 +1,54 @@
+import { supabase } from '../lib/supabaseClient';
+
+/**
+ * 취소정책 텍스트 형태로 조회
+ */
+export const getCancellationPoliciesText = async (): Promise<string> => {
+  try {
+    const { data: policiesData, error: policyError } = await supabase
+      .from('cancellation_policies')
+      .select('period_desc, fee_desc')
+      .order('id');
+
+    if (policyError) {
+      console.error('취소정책 조회 오류:', policyError);
+      return '취소정책 정보를 불러오는 중 오류가 발생했습니다.';
+    }
+
+    if (!policiesData || policiesData.length === 0) {
+      return '취소정책 정보가 없습니다.';
+    }
+
+    const policyTexts = policiesData.map((policy, index) => {
+      const feeText = policy.fee_desc === '없음' ? '무료 취소' : `취소 수수료: ${policy.fee_desc}`;
+      return `• ${policy.period_desc}: ${feeText}`;
+    });
+
+    return policyTexts.join('\n');
+  } catch (error) {
+    console.error('취소정책 가져오기 오류:', error);
+    return '취소정책 정보를 불러오는 중 오류가 발생했습니다.';
+  }
+};
+
+/**
+ * 취소정책 전체 조회
+ */
+export const getCancellationPolicies = async () => {
+  try {
+    const { data, error } = await supabase
+      .from('cancellation_policies')
+      .select('*')
+      .order('id');
+
+    if (error) {
+      console.error('취소정책 조회 오류:', error);
+      throw error;
+    }
+
+    return data;
+  } catch (error) {
+    console.error('취소정책 조회 중 오류:', error);
+    throw error;
+  }
+}; 

--- a/backend/src/concerts/concerts.service.ts
+++ b/backend/src/concerts/concerts.service.ts
@@ -1,5 +1,6 @@
 import { Concert } from './concerts.model';
 import { supabase } from '../lib/supabaseClient';
+import { getCancellationPolicies } from '../cancellation_policies/cancellation_policies.service';
 
 /* ─────────────────────── 공통 헬퍼 ─────────────────────── */
 
@@ -335,12 +336,7 @@ export const getConcertDetail = async (concertId: string) => {
   const seat_prices = await fetchSeatPrices(concertId, true);
 
   /* 3) 취소 정책 */
-  const { data: policiesData, error: policyError } = await supabase
-    .from('cancellation_policies')
-    .select('period_desc, fee_desc')
-    .eq('concert_id', concertId);
-
-  if (policyError) throw policyError;
+  const policiesData = await getCancellationPolicies();
 
   return {
     concert: concertData,

--- a/blockchain/cache/solidity-files-cache.json
+++ b/blockchain/cache/solidity-files-cache.json
@@ -2,7 +2,7 @@
   "_format": "hh-sol-cache-2",
   "files": {
     "/home/ubuntu/Tickity/blockchain/contracts/SoulboundTicket.sol": {
-      "lastModificationDate": 1751387602148,
+      "lastModificationDate": 1751078892575,
       "contentHash": "3da2c07f71f0cf9a3cf8be340ae0b3b5",
       "sourceName": "contracts/SoulboundTicket.sol",
       "solcConfig": {
@@ -48,7 +48,7 @@
       ]
     },
     "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/access/Ownable.sol": {
-      "lastModificationDate": 1751387666013,
+      "lastModificationDate": 1750837983566,
       "contentHash": "d3c790edc9ccf808a17c5a6cd13614fd",
       "sourceName": "@openzeppelin/contracts/access/Ownable.sol",
       "solcConfig": {
@@ -93,7 +93,7 @@
       ]
     },
     "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/token/ERC721/ERC721.sol": {
-      "lastModificationDate": 1751387665865,
+      "lastModificationDate": 1750837982850,
       "contentHash": "a7951c81f7037d558c6d2f220b0cb38e",
       "sourceName": "@openzeppelin/contracts/token/ERC721/ERC721.sol",
       "solcConfig": {
@@ -144,7 +144,7 @@
       ]
     },
     "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/utils/Context.sol": {
-      "lastModificationDate": 1751387665637,
+      "lastModificationDate": 1750837981818,
       "contentHash": "67bfbc07588eb8683b3fd8f6f909563e",
       "sourceName": "@openzeppelin/contracts/utils/Context.sol",
       "solcConfig": {
@@ -187,7 +187,7 @@
       ]
     },
     "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/utils/Strings.sol": {
-      "lastModificationDate": 1751387666052,
+      "lastModificationDate": 1750837983726,
       "contentHash": "13dbc135f563c72a11b1cf4fbb5fb284",
       "sourceName": "@openzeppelin/contracts/utils/Strings.sol",
       "solcConfig": {
@@ -234,7 +234,7 @@
       ]
     },
     "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/interfaces/draft-IERC6093.sol": {
-      "lastModificationDate": 1751387665717,
+      "lastModificationDate": 1750837982374,
       "contentHash": "267d92fe4de67b1bdb3302c08f387dbf",
       "sourceName": "@openzeppelin/contracts/interfaces/draft-IERC6093.sol",
       "solcConfig": {
@@ -279,7 +279,7 @@
       ]
     },
     "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/utils/introspection/ERC165.sol": {
-      "lastModificationDate": 1751387665828,
+      "lastModificationDate": 1750837982686,
       "contentHash": "7c03c1e37c3dc24eafb76dc2b8a5c3a6",
       "sourceName": "@openzeppelin/contracts/utils/introspection/ERC165.sol",
       "solcConfig": {
@@ -324,7 +324,7 @@
       ]
     },
     "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/token/ERC721/IERC721.sol": {
-      "lastModificationDate": 1751387665981,
+      "lastModificationDate": 1750837983418,
       "contentHash": "1fdc621cd6747e8985e11fc76ce74511",
       "sourceName": "@openzeppelin/contracts/token/ERC721/IERC721.sol",
       "solcConfig": {
@@ -368,8 +368,53 @@
         "IERC721"
       ]
     },
+    "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol": {
+      "lastModificationDate": 1750837983454,
+      "contentHash": "12c206f185cb951213799561fdcaa40d",
+      "sourceName": "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol",
+      "solcConfig": {
+        "version": "0.8.28",
+        "settings": {
+          "optimizer": {
+            "enabled": true,
+            "runs": 200
+          },
+          "evmVersion": "paris",
+          "outputSelection": {
+            "*": {
+              "*": [
+                "abi",
+                "evm.bytecode",
+                "evm.deployedBytecode",
+                "evm.methodIdentifiers",
+                "metadata",
+                "devdoc",
+                "userdoc",
+                "storageLayout",
+                "evm.gasEstimates"
+              ],
+              "": [
+                "ast"
+              ]
+            }
+          },
+          "metadata": {
+            "useLiteralContent": true
+          }
+        }
+      },
+      "imports": [
+        "../IERC721.sol"
+      ],
+      "versionPragmas": [
+        "^0.8.20"
+      ],
+      "artifacts": [
+        "IERC721Metadata"
+      ]
+    },
     "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/token/ERC721/utils/ERC721Utils.sol": {
-      "lastModificationDate": 1751387665881,
+      "lastModificationDate": 1750837982914,
       "contentHash": "e12814872b31b0af06106796a6621b04",
       "sourceName": "@openzeppelin/contracts/token/ERC721/utils/ERC721Utils.sol",
       "solcConfig": {
@@ -414,141 +459,8 @@
         "ERC721Utils"
       ]
     },
-    "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol": {
-      "lastModificationDate": 1751387665985,
-      "contentHash": "12c206f185cb951213799561fdcaa40d",
-      "sourceName": "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol",
-      "solcConfig": {
-        "version": "0.8.28",
-        "settings": {
-          "optimizer": {
-            "enabled": true,
-            "runs": 200
-          },
-          "evmVersion": "paris",
-          "outputSelection": {
-            "*": {
-              "*": [
-                "abi",
-                "evm.bytecode",
-                "evm.deployedBytecode",
-                "evm.methodIdentifiers",
-                "metadata",
-                "devdoc",
-                "userdoc",
-                "storageLayout",
-                "evm.gasEstimates"
-              ],
-              "": [
-                "ast"
-              ]
-            }
-          },
-          "metadata": {
-            "useLiteralContent": true
-          }
-        }
-      },
-      "imports": [
-        "../IERC721.sol"
-      ],
-      "versionPragmas": [
-        "^0.8.20"
-      ],
-      "artifacts": [
-        "IERC721Metadata"
-      ]
-    },
-    "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/utils/math/SignedMath.sol": {
-      "lastModificationDate": 1751387666047,
-      "contentHash": "ae3528afb8bdb0a7dcfba5b115ee8074",
-      "sourceName": "@openzeppelin/contracts/utils/math/SignedMath.sol",
-      "solcConfig": {
-        "version": "0.8.28",
-        "settings": {
-          "optimizer": {
-            "enabled": true,
-            "runs": 200
-          },
-          "evmVersion": "paris",
-          "outputSelection": {
-            "*": {
-              "*": [
-                "abi",
-                "evm.bytecode",
-                "evm.deployedBytecode",
-                "evm.methodIdentifiers",
-                "metadata",
-                "devdoc",
-                "userdoc",
-                "storageLayout",
-                "evm.gasEstimates"
-              ],
-              "": [
-                "ast"
-              ]
-            }
-          },
-          "metadata": {
-            "useLiteralContent": true
-          }
-        }
-      },
-      "imports": [
-        "./SafeCast.sol"
-      ],
-      "versionPragmas": [
-        "^0.8.20"
-      ],
-      "artifacts": [
-        "SignedMath"
-      ]
-    },
-    "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/utils/math/SafeCast.sol": {
-      "lastModificationDate": 1751387666035,
-      "contentHash": "2adca1150f58fc6f3d1f0a0f22ee7cca",
-      "sourceName": "@openzeppelin/contracts/utils/math/SafeCast.sol",
-      "solcConfig": {
-        "version": "0.8.28",
-        "settings": {
-          "optimizer": {
-            "enabled": true,
-            "runs": 200
-          },
-          "evmVersion": "paris",
-          "outputSelection": {
-            "*": {
-              "*": [
-                "abi",
-                "evm.bytecode",
-                "evm.deployedBytecode",
-                "evm.methodIdentifiers",
-                "metadata",
-                "devdoc",
-                "userdoc",
-                "storageLayout",
-                "evm.gasEstimates"
-              ],
-              "": [
-                "ast"
-              ]
-            }
-          },
-          "metadata": {
-            "useLiteralContent": true
-          }
-        }
-      },
-      "imports": [],
-      "versionPragmas": [
-        "^0.8.20"
-      ],
-      "artifacts": [
-        "SafeCast"
-      ]
-    },
     "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/utils/math/Math.sol": {
-      "lastModificationDate": 1751387666000,
+      "lastModificationDate": 1750837983530,
       "contentHash": "5ec781e33d3a9ac91ffdc83d94420412",
       "sourceName": "@openzeppelin/contracts/utils/math/Math.sol",
       "solcConfig": {
@@ -593,8 +505,96 @@
         "Math"
       ]
     },
+    "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/utils/math/SafeCast.sol": {
+      "lastModificationDate": 1750837983662,
+      "contentHash": "2adca1150f58fc6f3d1f0a0f22ee7cca",
+      "sourceName": "@openzeppelin/contracts/utils/math/SafeCast.sol",
+      "solcConfig": {
+        "version": "0.8.28",
+        "settings": {
+          "optimizer": {
+            "enabled": true,
+            "runs": 200
+          },
+          "evmVersion": "paris",
+          "outputSelection": {
+            "*": {
+              "*": [
+                "abi",
+                "evm.bytecode",
+                "evm.deployedBytecode",
+                "evm.methodIdentifiers",
+                "metadata",
+                "devdoc",
+                "userdoc",
+                "storageLayout",
+                "evm.gasEstimates"
+              ],
+              "": [
+                "ast"
+              ]
+            }
+          },
+          "metadata": {
+            "useLiteralContent": true
+          }
+        }
+      },
+      "imports": [],
+      "versionPragmas": [
+        "^0.8.20"
+      ],
+      "artifacts": [
+        "SafeCast"
+      ]
+    },
+    "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/utils/math/SignedMath.sol": {
+      "lastModificationDate": 1750837983690,
+      "contentHash": "ae3528afb8bdb0a7dcfba5b115ee8074",
+      "sourceName": "@openzeppelin/contracts/utils/math/SignedMath.sol",
+      "solcConfig": {
+        "version": "0.8.28",
+        "settings": {
+          "optimizer": {
+            "enabled": true,
+            "runs": 200
+          },
+          "evmVersion": "paris",
+          "outputSelection": {
+            "*": {
+              "*": [
+                "abi",
+                "evm.bytecode",
+                "evm.deployedBytecode",
+                "evm.methodIdentifiers",
+                "metadata",
+                "devdoc",
+                "userdoc",
+                "storageLayout",
+                "evm.gasEstimates"
+              ],
+              "": [
+                "ast"
+              ]
+            }
+          },
+          "metadata": {
+            "useLiteralContent": true
+          }
+        }
+      },
+      "imports": [
+        "./SafeCast.sol"
+      ],
+      "versionPragmas": [
+        "^0.8.20"
+      ],
+      "artifacts": [
+        "SignedMath"
+      ]
+    },
     "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/utils/Panic.sol": {
-      "lastModificationDate": 1751387666024,
+      "lastModificationDate": 1750837983618,
       "contentHash": "2133dc13536b4a6a98131e431fac59e1",
       "sourceName": "@openzeppelin/contracts/utils/Panic.sol",
       "solcConfig": {
@@ -637,7 +637,7 @@
       ]
     },
     "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/utils/introspection/IERC165.sol": {
-      "lastModificationDate": 1751387665958,
+      "lastModificationDate": 1750837983278,
       "contentHash": "bf0119eb2a570f219729ff38b6cd1df8",
       "sourceName": "@openzeppelin/contracts/utils/introspection/IERC165.sol",
       "solcConfig": {
@@ -680,7 +680,7 @@
       ]
     },
     "/home/ubuntu/Tickity/blockchain/node_modules/@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol": {
-      "lastModificationDate": 1751387665986,
+      "lastModificationDate": 1750837983470,
       "contentHash": "729ce0904eb533489ffcc3bfe91237d4",
       "sourceName": "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol",
       "solcConfig": {

--- a/frontend/src/app/concert/[slug]/types/index.ts
+++ b/frontend/src/app/concert/[slug]/types/index.ts
@@ -29,6 +29,7 @@ export interface SeatPrice {
 }
 
 export interface CancellationPolicy {
+  id: string;
   period_desc: string;
   fee_desc: string;
 }


### PR DESCRIPTION
- feat: cancellation_policies.service.ts 생성하여 취소정책 비즈니스 로직 분리
 - refactor: chatbot.service.ts에서 취소정책 로직을 전용 서비스로 이동 
 - refactor: concerts.service.ts에서 취소정책 조회 시 서비스 함수 사용
 - fix: 챗봇에서 띄어쓰기 없는 "예매방법" 등 키워드 인식 추가
 - fix: CancellationPolicy 타입 일관성 수정  
 - 백엔드: concert_id 필드 제거 (이미 DB에서 삭제됨)   
 - 프론트엔드: id 필드 추가하여 API 응답과 일치  
 ✅ 테스트 완료: 
- 콘서트 상세 조회 API 취소정책 정상 반환 
- 챗봇 취소정책 조회 정상 작동 
- 챗봇 예매방법 문의 띄어쓰기 무관하게 정상 응답