### PR TITLE
refactor: concerts 테이블의 date 컬럼 제거

### DIFF
--- a/backend/src/concerts/concerts.model.ts
+++ b/backend/src/concerts/concerts.model.ts
@@ -1,7 +1,6 @@
 export interface Concert {
   id: string;
   title: string;
-  date?: string; // 선택적 필드로 변경 - 하위 호환성을 위해 유지
   start_date: string; // 공연 시작 날짜 (YYYY-MM-DD 형태)
   start_time: string; // 공연 시작 시간 (HH:mm 형태)
   venue_id: string;

--- a/backend/src/concerts/concerts.service.ts
+++ b/backend/src/concerts/concerts.service.ts
@@ -96,12 +96,11 @@ export const getConcertById = async (concertId: string): Promise<Concert | null>
  */
 export const createConcert = async (concert: Omit<Concert, 'id' | 'created_at'>): Promise<Concert | null> => {
   try {
-    // start_date와 start_time이 있으면 자동으로 date 생성
+    // 입력 데이터 검증
     const concertData = {
       ...concert,
-      date: concert.start_date && concert.start_time 
-        ? `${concert.start_date}T${concert.start_time}` 
-        : concert.date || null
+      // date 필드는 더 이상 사용하지 않음
+      // start_date와 start_time만 사용
     };
 
     const { data: newConcert, error } = await supabase
@@ -157,7 +156,6 @@ export const getConcerts = async (category?: string, availableOnly: boolean = fa
       id,
       title,
       main_performer,
-      date,
       start_date,
       start_time,
       poster_url,
@@ -189,7 +187,6 @@ export const getConcerts = async (category?: string, availableOnly: boolean = fa
     id: c.id,
     title: c.title,
     main_performer: c.main_performer,
-    date: c.start_date && c.start_time ? `${c.start_date}T${c.start_time}` : null,
     start_date: c.start_date,
     start_time: c.start_time,
     poster_url: c.poster_url,

--- a/backend/src/tickets/tickets.service.ts
+++ b/backend/src/tickets/tickets.service.ts
@@ -33,7 +33,8 @@ export interface TicketWithDetails extends Ticket {
   concert?: {
     id: string;
     title: string;
-    date: string;
+    start_date: string;
+    start_time: string;
     venue_name: string;
     poster_url?: string;
   };
@@ -150,8 +151,9 @@ export const getUserTickets = async (
       *,
       concerts ( 
         id, 
-        title, 
-        date, 
+        title,
+        start_date,
+        start_time, 
         poster_url,
         venues ( name )
       ),
@@ -170,7 +172,8 @@ export const getUserTickets = async (
     concert: t.concerts && {
       id:         t.concerts.id,
       title:      t.concerts.title,
-      date:       t.concerts.date,
+      start_date: t.concerts.start_date,
+      start_time: t.concerts.start_time,
       venue_name: t.concerts.venues?.name || '장소 정보 없음',
       poster_url: t.concerts.poster_url,
     },
@@ -198,7 +201,8 @@ export const getTicketById = async (
       concerts ( 
         id, 
         title, 
-        date, 
+        start_date,
+        start_time,
         poster_url,
         venues ( name )
       ),
@@ -219,7 +223,8 @@ export const getTicketById = async (
     concert: data.concerts && {
       id:         data.concerts.id,
       title:      data.concerts.title,
-      date:       data.concerts.date,
+      start_date: data.concerts.start_date,
+      start_time: data.concerts.start_time,
       venue_name: data.concerts.venues?.name || '장소 정보 없음',
       poster_url: data.concerts.poster_url,
     },

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -181,7 +181,7 @@ router.get('/dashboard/:userId', /* authenticateToken, */ async (req: Request, r
       upcoming: userTickets.filter(ticket => 
         !ticket.is_used && 
         !ticket.canceled_at && 
-        new Date(ticket.concert?.date || '') > new Date()
+        new Date(ticket.concert?.start_date || '') > new Date()
       ).length,
       canceled: userTickets.filter(ticket => ticket.canceled_at).length
     };
@@ -263,7 +263,9 @@ router.get('/tickets/:userId', /* authenticateToken, */ async (req: Request, res
         price: ticket.purchase_price.toLocaleString() + '원',
         status: status,
         purchaseDate: new Date(ticket.created_at).toLocaleDateString('ko-KR'),
-        concertDate: ticket.concert?.date ? new Date(ticket.concert.date).toLocaleDateString('ko-KR') : '날짜 정보 없음',
+        concertDate: ticket.concert?.start_date 
+          ? new Date(ticket.concert.start_date).toLocaleDateString('ko-KR') 
+          : '날짜 정보 없음',
         venueName: ticket.concert?.venue_name || '장소 정보 없음',
         raw: ticket // 원본 데이터도 포함
       };
@@ -276,7 +278,7 @@ router.get('/tickets/:userId', /* authenticateToken, */ async (req: Request, res
       upcoming: userTickets.filter(ticket => 
         !ticket.is_used && 
         !ticket.canceled_at && 
-        new Date(ticket.concert?.date || '') > new Date()
+        new Date(ticket.concert?.start_date || '') > new Date()
       ).length,
       canceled: userTickets.filter(ticket => ticket.canceled_at).length
     };

--- a/frontend/src/app/concert/[slug]/types/index.ts
+++ b/frontend/src/app/concert/[slug]/types/index.ts
@@ -1,20 +1,36 @@
 export interface Concert {
   id: string;
   title: string;
-  main_performer: string;
   start_date: string;
   start_time: string;
-  poster_url: string;
   venue_id: string;
-  running_time: string;
+  poster_url?: string;
+  created_at: string;
+  organizer: string;
   promoter: string;
   customer_service: string;
+  running_time: string;
   age_rating: string;
+  main_performer: string;
   booking_fee: number;
+  shipping_note: string;
   valid_from: string;
   valid_to: string;
-  ticket_open_at: string;
-  venues: {
+  mobile_ticket_supported: boolean;
+  android_min_version: string;
+  ios_min_version: string;
+  id_doc_required: boolean;
+  seller_name: string;
+  seller_rep: string;
+  seller_reg_no: string;
+  seller_email: string;
+  seller_contact: string;
+  seller_address: string;
+  category: string;
+  round?: number;
+  ticket_open_at?: string;
+  venues?: {
+    id: string;
     name: string;
     address: string;
     capacity: number;


### PR DESCRIPTION
1. 데이터베이스 변경:
- concerts 테이블에서 date 컬럼 제거
- public_concerts 뷰 삭제

2. 백엔드 코드 수정:
- concerts.service.ts: date 필드 대신 start_date와 start_time 사용
- tickets.service.ts: 티켓 조회 시 date 대신 start_date 사용
- users.controller.ts: 티켓 정보 반환 시 date 대신 start_date 사용

3. 프론트엔드 인터페이스:
- ReservationItem 인터페이스에서 date, time 필드 제거
- start_date와 start_time으로 통일된 필드명 사용

모든 날짜/시간 관련 필드를 start_date와 start_time으로 통일하여 일관성 향상