### PR TITLE
REFACTOR: 사용하지 않는 BLOCKCHAIN_HOST/PORT 환경변수 제거(노션에 반영됨)

### DIFF
--- a/backend/src/config/environment.ts
+++ b/backend/src/config/environment.ts
@@ -3,12 +3,6 @@ export const getEnvironmentConfig = () => {
   const isDevelopment = process.env.NODE_ENV === 'development' || !process.env.NODE_ENV;
   
   // 환경변수 검증
-  if (!process.env.BLOCKCHAIN_HOST) {
-    throw new Error('BLOCKCHAIN_HOST 환경변수가 설정되지 않았습니다.');
-  }
-  if (!process.env.BLOCKCHAIN_PORT) {
-    throw new Error('BLOCKCHAIN_PORT 환경변수가 설정되지 않았습니다.');
-  }
   if (!process.env.FRONTEND_URL) {
     throw new Error('FRONTEND_URL 환경변수가 설정되지 않았습니다.');
   }
@@ -21,8 +15,6 @@ export const getEnvironmentConfig = () => {
     FRONTEND_URL: process.env.FRONTEND_URL,
     BACKEND_URL: process.env.BACKEND_URL,
     NODE_ENV: process.env.NODE_ENV || 'production',
-    BLOCKCHAIN_HOST: process.env.BLOCKCHAIN_HOST,
-    BLOCKCHAIN_PORT: process.env.BLOCKCHAIN_PORT
   };
 };
 
@@ -39,9 +31,7 @@ export const getDynamicConfig = (req?: any) => {
   // localhost 감지
   const isLocalhost = origin?.includes('localhost') || 
                      origin?.includes('127.0.0.1') || 
-                     origin?.includes(process.env.BLOCKCHAIN_HOST) || 
                      host?.includes('localhost') || 
-                     host?.includes(process.env.BLOCKCHAIN_HOST) || 
                      host?.includes('127.0.0.1');
 
   if (isLocalhost) {


### PR DESCRIPTION
- backend/src/config/environment.ts에서 BLOCKCHAIN_HOST/PORT 관련 코드 제거
- 실제로는 RPC_URL만 사용하므로 불필요한 환경변수 정리
- 환경변수 검증 및 동적 설정 로직에서 BLOCKCHAIN_HOST 참조 제거