### PR TITLE
Refactor: 취소정책 변경에 따른 코드 수정

### DIFF
--- a/backend/src/chatbot/chatbot.service.ts
+++ b/backend/src/chatbot/chatbot.service.ts
@@ -586,14 +586,19 @@ const generateMockResponse = async (
     const activeTickets = tickets.filter(ticket => !ticket.canceled_at && !ticket.is_used);
     const realCancellationPolicies = await getCancellationPoliciesText();
     
-    if (activeTickets.length > 0) {
+    if (activeTickets.length === 0) {
+      return {
+        message: '현재 취소 가능한 티켓이 없습니다. 😔\n\n취소 가능한 조건:\n• 아직 사용하지 않은 티켓\n• 이미 취소되지 않은 티켓\n\n다른 도움이 필요하시면 언제든 말씀해 주세요!',
+        suggestions: generateSuggestions(intent),
+        needsUserInfo: false,
+        actionType: 'show_tickets'
+      };
+    } else {
       const ticketList = activeTickets.map((ticket, index) => 
         `${index + 1}. ${ticket.concert?.title || '콘서트 정보 없음'}\n   🪑 ${ticket.seat?.label || (ticket.seat?.row_idx && ticket.seat?.col_idx ? `${ticket.seat.row_idx}열 ${ticket.seat.col_idx}번` : '좌석 정보 없음')} (${ticket.seat?.grade_name || '등급 정보 없음'})\n   💰 ${ticket.purchase_price.toLocaleString()}원\n   📅 ${new Date(ticket.created_at).toLocaleDateString('ko-KR')} 예매`
       ).join('\n\n');
       
-      message = `취소 가능한 티켓 목록입니다: 🎫\n\n${ticketList}\n\n⚠️ 티켓 취소 안내:\n${realCancellationPolicies}\n\n취소를 원하시면 고객센터(1588-1234)로 연락해 주세요.`;
-    } else {
-      message = `현재 취소 가능한 티켓이 없습니다. 😔\n\n취소 가능한 조건:\n• 아직 사용하지 않은 티켓\n• 이미 취소되지 않은 티켓\n\n다른 도움이 필요하시면 언제든 말씀해 주세요!`;
+      message = `취소 가능한 티켓 목록입니다: 🎫\n\n${ticketList}\n\n⚠️ 티켓 취소 안내:\n${realCancellationPolicies}\n\n티켓 취소를 원하시면 <a href="/mypage" class="text-blue-500 hover:text-blue-700">마이페이지</a>에서 진행하실 수 있습니다.`;
     }
     actionType = 'show_tickets';
     
@@ -608,7 +613,11 @@ const generateMockResponse = async (
   }
   
   if (intent === 'cancellation' && !userId) {
-    const realCancellationPolicies = await getCancellationPoliciesText();
+    const realCancellationPolicies = `• 관람일 10일 전까지: 수수료 없음
+• 관람일 9일~7일 전: 티켓금액의 10%
+• 관람일 6일~3일 전: 티켓금액의 20%
+• 관람일 2일~1일 전: 티켓금액의 30%
+• 관람 당일: 취소 불가`;
     
     message = `티켓 취소를 위해서는 로그인이 필요합니다. 🔐\n\n로그인 후 다시 시도해 주세요.\n\n취소 정책:\n${realCancellationPolicies}`;
     actionType = 'show_tickets';
@@ -800,7 +809,11 @@ if (intent === 'booking_period' && artistName) {
       let message = '';
       
       if (intent === 'cancellation') {
-        const realCancellationPolicies = await getCancellationPoliciesText();
+        const realCancellationPolicies = `• 관람일 10일 전까지: 수수료 없음
+• 관람일 9일~7일 전: 티켓금액의 10%
+• 관람일 6일~3일 전: 티켓금액의 20%
+• 관람일 2일~1일 전: 티켓금액의 30%
+• 관람 당일: 취소 불가`;
         message = `티켓 취소를 위해서는 로그인이 필요합니다. 🔐\n\n로그인 후 다시 시도해 주세요.\n\n취소 정책:\n${realCancellationPolicies}`;
       } else {
         message = '이 기능을 이용하려면 로그인이 필요합니다. 로그인 후 다시 시도해 주세요.';
@@ -892,7 +905,7 @@ if (intent === 'booking_period' && artistName) {
           return `${index + 1}. ${ticket.concert?.title || '콘서트 정보 없음'}\n   - 좌석: ${seatInfo} (${ticket.seat?.grade_name})\n   - 가격: ${ticket.purchase_price?.toLocaleString() || '가격 정보 없음'}원\n   - 예매일: ${ticket.created_at ? new Date(ticket.created_at).toLocaleDateString('ko-KR') : '날짜 정보 없음'}`;
         }).join('\n\n');
         return {
-          message: `취소 가능한 티켓 목록입니다: 🎫\n\n${ticketList}\n\n⚠️ 티켓 취소 안내:\n${realCancellationPolicies}\n\n취소를 원하시면 고객센터(1588-1234)로 연락해 주세요.`,
+          message: `취소 가능한 티켓 목록입니다: 🎫\n\n${ticketList}\n\n⚠️ 티켓 취소 안내:\n${realCancellationPolicies}\n\n티켓 취소를 원하시면 <a href="/mypage" class="text-blue-500 hover:text-blue-700">마이페이지</a>에서 진행하실 수 있습니다.`,
           suggestions: generateSuggestions(intent),
           needsUserInfo: false,
           actionType: 'show_tickets'

--- a/backend/src/concerts/concerts.service.ts
+++ b/backend/src/concerts/concerts.service.ts
@@ -493,26 +493,19 @@ export const validateConcertSchedule = (
   }
 
   // 2. 취소정책 조건 검증
-  // 현재 취소정책: 예매 후 7일 이내 무료, 예매 후 8일~관람일 10일전까지 유료
-  // "예매 후 8일~관람일 10일전까지" 구간이 존재하려면: 예매 종료일 + 8일 ≤ 공연일 - 10일
-  // 즉, 예매 종료일 ≤ 공연일 - 18일 (18일 이상 간격 필요)
-  
-  const eightDaysAfterBookingEnd = new Date(bookingEnd);
-  eightDaysAfterBookingEnd.setDate(eightDaysAfterBookingEnd.getDate() + 8);
-
+  // 새로운 취소정책: 관람일 10일 전까지 취소 가능
   const tenDaysBeforePerformance = new Date(performanceDate);
   tenDaysBeforePerformance.setDate(tenDaysBeforePerformance.getDate() - 10);
 
-  // 예매 종료일로부터 8일 후가 공연일 10일 전보다 뒤에 있으면 문제
-  if (eightDaysAfterBookingEnd > tenDaysBeforePerformance) {
+  if (bookingEnd > tenDaysBeforePerformance) {
     const actualGap = Math.ceil((performanceDate.getTime() - bookingEnd.getTime()) / (1000 * 60 * 60 * 24));
     return {
       isValid: false,
-      errorMessage: `취소정책 조건을 만족하지 않습니다. 예매 종료일과 공연 날짜 사이에 최소 18일의 간격이 필요합니다. (현재: ${actualGap}일) "예매 후 8일~관람일 10일전까지" 수수료 구간이 존재하지 않습니다.`
+      errorMessage: `예매 종료일은 공연일 10일 전까지여야 합니다. (현재: 공연일 ${actualGap}일 전)`
     };
   }
 
-  // 3. 최소 예매 기간 검증 (최소 1일은 예매 기간이 있어야 함)
+  // 3. 최소 예매 기간 검증
   const bookingPeriodMs = bookingEnd.getTime() - bookingStart.getTime();
   const bookingPeriodDays = Math.ceil(bookingPeriodMs / (1000 * 60 * 60 * 24));
   

--- a/frontend/src/app/admin/concert-create/page.tsx
+++ b/frontend/src/app/admin/concert-create/page.tsx
@@ -254,22 +254,15 @@ export default function ConcertCreatePage() {
       }
       
       // 2. 취소정책 조건 검증
-      // 현재 취소정책: 예매 후 7일 이내 무료, 예매 후 8일~관람일 10일전까지 유료
-      // "예매 후 8일~관람일 10일전까지" 구간이 존재하려면: 예매 종료일 + 8일 ≤ 공연일 - 10일
-      // 즉, 예매 종료일 ≤ 공연일 - 18일 (18일 이상 간격 필요)
-      
-      const eightDaysAfterBookingEnd = new Date(bookingEnd);
-      eightDaysAfterBookingEnd.setDate(eightDaysAfterBookingEnd.getDate() + 8);
-      
+      // 새로운 취소정책: 관람일 10일 전까지 취소 가능
       const tenDaysBeforePerformance = new Date(performanceDate);
       tenDaysBeforePerformance.setDate(tenDaysBeforePerformance.getDate() - 10);
       
-      // 예매 종료일로부터 8일 후가 공연일 10일 전보다 뒤에 있으면 문제
-      if (eightDaysAfterBookingEnd > tenDaysBeforePerformance) {
+      if (bookingEnd > tenDaysBeforePerformance) {
         const actualGap = Math.ceil((performanceDate.getTime() - bookingEnd.getTime()) / (1000 * 60 * 60 * 24));
         return { 
           isValid: false, 
-          errorMessage: `취소정책 조건을 만족하지 않습니다. 예매 종료일과 공연 날짜 사이에 최소 18일의 간격이 필요합니다. (현재: ${actualGap}일) "예매 후 8일~관람일 10일전까지" 수수료 구간이 존재하지 않습니다.`
+          errorMessage: `예매 종료일은 공연일 10일 전까지여야 합니다. (현재: 공연일 ${actualGap}일 전)`
         };
       }
       


### PR DESCRIPTION
1. 취소정책 변경
- 관람일 10일 전까지: 수수료 없음
- 관람일 9일~7일 전: 티켓금액의 10%
- 관람일 6일~3일 전: 티켓금액의 20%
- 관람일 2일~1일 전: 티켓금액의 30%

2. 백엔드 수정
- concerts.service.ts: 콘서트 등록 시 18일 제한 로직 제거
- chatbot.service.ts: 취소정책 안내 메시지 DB 연동

3. 프론트엔드 수정
- concert-create/page.tsx: 날짜 검증 로직 간소화
- 예매 종료일 제한을 공연 10일 전으로 변경