### PR TITLE
FIX: QR 코드 인증 시 사용된 티켓 검증 로직 수정

### DIFF
--- a/backend/src/blockchain/verification.service.ts
+++ b/backend/src/blockchain/verification.service.ts
@@ -127,11 +127,16 @@ export class BlockchainVerificationService {
       const dbIsUsed = dbTicket.is_used;
       const blockchainIsUsed = blockchainTicket.isUsed;
 
+      // 4. 입장 가능 여부 검증 (사용되지 않은 티켓만 유효)
+      const isNotUsed = !dbIsUsed && !blockchainIsUsed;
+      const isConsistent = dbIsUsed === blockchainIsUsed;
+
       return {
-        isValid: dbIsUsed === blockchainIsUsed,
+        isValid: isNotUsed && isConsistent,
         dbIsUsed,
         blockchainIsUsed,
-        error: dbIsUsed !== blockchainIsUsed ? 'DB와 블록체인 사용 상태 불일치' : undefined
+        error: !isNotUsed ? '이미 사용된 티켓입니다' : 
+               !isConsistent ? 'DB와 블록체인 사용 상태 불일치' : undefined
       };
 
     } catch (error) {


### PR DESCRIPTION
## 변경사항

### 사용 상태 검증 로직 개선 (backend/src/blockchain/verification.service.ts)
- 기존: DB와 블록체인 상태 일치 시 검증 성공 (이미 사용된 티켓도 성공으로 표시)
- 수정: 사용되지 않은 티켓만 검증 성공, 이미 사용된 티켓은 검증 실패로 표시
- 에러 메시지: '이미 사용된 티켓입니다'

## 해결된 문제
- 이미 사용된 티켓을 재스캔 시 검증 결과가 초록색 체크로 표시되는 문제 해결
- 사용 불가 메시지와 검증 결과가 일치하도록 수정