### PR TITLE
중복 예매 방지 및 좌석 상태 개선, 티켓 데이터 조회 방식 및 UI 정리

### DIFF
--- a/frontend/src/app/components/SeatGrid.tsx
+++ b/frontend/src/app/components/SeatGrid.tsx
@@ -162,7 +162,7 @@ const SeatGrid: FC<SeatGridProps> = ({ concertId, sectionId, onSeatSelect }) => 
 
   const handleSeatClick = (rowIdx: number, colIdx: number) => {
     const seat = seatMap[rowIdx]?.[colIdx];
-    if (!seat || seat.status === 'sold') return;
+    if (!seat || ['sold', 'hold'].includes(seat.status.toLowerCase())) return;
 
     const seatKey = `${zoneCode}구역 ${rowIdx + 1}열 ${String(colIdx + 1).padStart(3, '0')}번`;
     const seatInfo = `${floor} ${seatKey}`;
@@ -270,27 +270,23 @@ const SeatGrid: FC<SeatGridProps> = ({ concertId, sectionId, onSeatSelect }) => 
                     </div>
                     <div className={`flex ${gap}`}>
                       {row.map((seat, colIdx) => (
-                        <div
-                          key={colIdx}
-                          onClick={() => handleSeatClick(rowIdx, colIdx)}
-                          className={`${seatSize} font-medium rounded-md cursor-pointer transition-all duration-200 flex items-center justify-center ${
-                            seat === null
-                              ? 'invisible'
-                              : seat.status === 'sold'
-                              ? 'bg-gray-200 cursor-not-allowed opacity-50'
-                              : seat.status === 'hold'
-                              ? 'bg-orange-200 cursor-not-allowed opacity-75'
-                              : sectionGrade === 'VIP석'
-                              ? selectedSeat === `${zoneCode}구역 ${rowIdx + 1}열 ${String(colIdx + 1).padStart(3, '0')}번`
-                                ? 'bg-pink-300 text-pink-900 shadow-lg ring-2 ring-pink-300'
-                                : 'bg-pink-200 hover:bg-pink-300 border border-pink-300 text-pink-800'
-                              : selectedSeat === `${zoneCode}구역 ${rowIdx + 1}열 ${String(colIdx + 1).padStart(3, '0')}번`
-                              ? 'bg-blue-500 text-white shadow-lg ring-2 ring-blue-300'
-                              : 'bg-blue-100 hover:bg-blue-200 border border-blue-200'
-                          }`}
-                        >
-                          
-                        </div>
+                      <div
+                        key={colIdx}
+                        onClick={() => handleSeatClick(rowIdx, colIdx)}
+                        className={`${seatSize} font-medium rounded-md cursor-pointer transition-all duration-200 flex items-center justify-center ${
+                          seat === null
+                            ? 'invisible'
+                            : ['sold', 'hold'].includes(seat.status.toLowerCase())
+                            ? 'bg-gray-200 cursor-not-allowed opacity-50'
+                            : sectionGrade === 'VIP석'
+                            ? selectedSeat === `${zoneCode}구역 ${rowIdx + 1}열 ${String(colIdx + 1).padStart(3, '0')}번`
+                              ? 'bg-pink-300 text-pink-900 shadow-lg ring-2 ring-pink-300'
+                              : 'bg-pink-200 hover:bg-pink-300 border border-pink-300 text-pink-800'
+                            : selectedSeat === `${zoneCode}구역 ${rowIdx + 1}열 ${String(colIdx + 1).padStart(3, '0')}번`
+                            ? 'bg-blue-500 text-white shadow-lg ring-2 ring-blue-300'
+                            : 'bg-blue-100 hover:bg-blue-200 border border-blue-200'
+                        }`}
+                      />
                       ))}
                     </div>
                   </div>

--- a/frontend/src/app/concert/[slug]/components/BookingBox.tsx
+++ b/frontend/src/app/concert/[slug]/components/BookingBox.tsx
@@ -10,6 +10,8 @@ interface BookingBoxProps {
   concert: Pick<Concert, 'start_date' | 'start_time' | 'ticket_open_at'>;
   price: string;
   calendarDays: Array<number | null>;
+  isDisabled?: boolean;       
+  disabledReason?: string;    
 }
 
 const BookingBox: React.FC<BookingBoxProps> = ({
@@ -20,7 +22,9 @@ const BookingBox: React.FC<BookingBoxProps> = ({
   onReservation,
   concert,
   price,
-  calendarDays
+  calendarDays,
+  isDisabled = false,
+  disabledReason,
 }) => {
   const now = new Date();
   const ticketOpenAt = concert.ticket_open_at ? new Date(concert.ticket_open_at) : null;
@@ -29,96 +33,108 @@ const BookingBox: React.FC<BookingBoxProps> = ({
   // 예매일 텍스트: 무조건 YYYY년 M월 D일 HH:mm 형식
   const renderOpenDate = () => {
     if (!ticketOpenAt) return null;
-
     const year = ticketOpenAt.getFullYear();
     const month = ticketOpenAt.getMonth() + 1;
     const date = ticketOpenAt.getDate();
     const hours = String(ticketOpenAt.getHours()).padStart(2, '0');
     const minutes = String(ticketOpenAt.getMinutes()).padStart(2, '0');
-
     return `${year}년 ${month}월 ${date}일 ${hours}:${minutes} | 예정`;
   };
 
   return (
-<div className="w-full max-w-[460px] rounded-2xl p-8 shadow-md">
-  <h3 className="text-lg font-semibold mb-5">관람일 선택</h3>
-  <div className="flex justify-between items-center mb-4 text-base">
-    <button className="text-gray-400" disabled>&lt;</button>
-    <span className="font-semibold text-gray-800">{selectedDate.slice(0, 7).replace('-', '년 ') + '월'}</span>
-    <button className="text-gray-400" disabled>&gt;</button>
-  </div>
-
-  <div className="grid grid-cols-7 gap-2 text-base mb-6 place-items-center font-semibold">
-    {['일', '월', '화', '수', '목', '금', '토'].map((d, i) => (
-      <div key={d} className={i === 0 ? 'text-red-500' : i === 6 ? 'text-blue-500' : 'text-gray-800'}>
-        {d}
+    <div className="w-full max-w-[460px] rounded-2xl p-8 shadow-md">
+      <h3 className="text-lg font-semibold mb-5">관람일 선택</h3>
+      <div className="flex justify-between items-center mb-4 text-base">
+        <button className="text-gray-400" disabled>&lt;</button>
+        <span className="font-semibold text-gray-800">
+          {selectedDate.slice(0, 7).replace('-', '년 ') + '월'}
+        </span>
+        <button className="text-gray-400" disabled>&gt;</button>
       </div>
-    ))}
-    {calendarDays.map((day, idx) => {
-      if (!day) return <div key={`empty-${idx}`} className="w-10 h-10" />;
-      
-      const baseDate = new Date(concert.start_date);
-      const year = baseDate.getFullYear();
-      const month = baseDate.getMonth() + 1;
-      const date = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
 
-      const isAvailable = date === concert.start_date;
-      const isSelected = selectedDate === date;
+      <div className="grid grid-cols-7 gap-2 text-base mb-6 place-items-center font-semibold">
+        {['일', '월', '화', '수', '목', '금', '토'].map((d, i) => (
+          <div key={d} className={i === 0 ? 'text-red-500' : i === 6 ? 'text-blue-500' : 'text-gray-800'}>
+            {d}
+          </div>
+        ))}
+        {calendarDays.map((day, idx) => {
+          if (!day) return <div key={`empty-${idx}`} className="w-10 h-10" />;
+          const baseDate = new Date(concert.start_date);
+          const year = baseDate.getFullYear();
+          const month = baseDate.getMonth() + 1;
+          const date = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+          const isAvailable = date === concert.start_date;
+          const isSelected = selectedDate === date;
+          const baseStyle = "w-10 h-10 flex items-center justify-center rounded-full text-base leading-none";
 
-      const baseStyle = "w-10 h-10 flex items-center justify-center rounded-full text-base leading-none";
+          return (
+            <button
+              key={day}
+              className={`${baseStyle} ${
+                isSelected
+                  ? 'bg-blue-500 text-white'
+                  : isAvailable
+                  ? 'hover:bg-gray-200 text-black'
+                  : 'text-gray-300 cursor-not-allowed'
+              }`}
+              onClick={() => isAvailable && onDateChange(date)}
+              disabled={!isAvailable}
+            >
+              {day}
+            </button>
+          );
+        })}
+      </div>
 
-      return (
+      <h3 className="text-lg font-semibold mb-4">회차 선택</h3>
+      <div className="space-y-3 mb-6">
+        {concert.start_time && (() => {
+          const label = concert.start_time.slice(0, 5);
+          const isSelected = selectedTime === label;
+          return (
+            <button
+              className={`w-full rounded-md px-5 py-3 flex justify-between items-center text-base cursor-pointer ${
+                isSelected ? 'bg-blue-500 text-white' : 'bg-gray-100 hover:bg-blue-100'
+              }`}
+              onClick={() => onTimeChange(label)}
+            >
+              <span>{label}</span>
+              <span className={`text-sm ${isSelected ? 'text-white' : 'text-gray-500'}`}>
+                {isSelected ? '선택됨' : '예매 가능'}
+              </span>
+            </button>
+          );
+        })()}
+      </div>
+
+      <div className="text-base text-gray-600 mb-2">선택 정보</div>
+      <div className="text-base font-medium mb-4">{selectedDate} {selectedTime}</div>
+      <div className="text-lg font-bold text-blue-600 mb-6">{price}</div>
+
+      {/* 예매 버튼 또는 예정 안내 */}
+      {isBeforeOpen ? (
+        <div className="w-full text-center text-base text-gray-500 py-4 bg-gray-100 rounded-md">
+          {renderOpenDate()}
+        </div>
+      ) : (
         <button
-          key={day}
-          className={`${baseStyle} ${isSelected ? 'bg-blue-500 text-white' : isAvailable ? 'hover:bg-gray-200 text-black' : 'text-gray-300 cursor-not-allowed'}`}
-          onClick={() => isAvailable && onDateChange(date)}
-          disabled={!isAvailable}
+          className={`w-full rounded-md py-4 font-semibold text-base cursor-pointer
+            ${!selectedTime || isDisabled
+              ? 'bg-gray-300 text-white cursor-not-allowed'
+              : 'bg-blue-600 text-white hover:bg-blue-700'}
+          `}
+          onClick={onReservation}
+          disabled={!selectedTime || isDisabled}
         >
-          {day}
+          {!selectedTime
+            ? '시간을 선택하세요'
+            : isDisabled
+            ? disabledReason || '예약 불가'
+            : '예약하기'}
         </button>
-      );
-    })}
-  </div>
-
-  <h3 className="text-lg font-semibold mb-4">회차 선택</h3>
-  <div className="space-y-3 mb-6">
-    {concert.start_time && (() => {
-      const label = `${concert.start_time.slice(0, 5)}`;
-      const isSelected = selectedTime === label;
-      return (
-        <button
-          className={`w-full rounded-md px-5 py-3 flex justify-between items-center text-base cursor-pointer ${isSelected ? 'bg-blue-500 text-white' : 'bg-gray-100 hover:bg-blue-100'}`}
-          onClick={() => onTimeChange(label)}
-        >
-          <span>{label}</span>
-          <span className={`text-sm ${isSelected ? 'text-white' : 'text-gray-500'}`}>
-            {isSelected ? '선택됨' : '예매 가능'}
-          </span>
-        </button>
-      );
-    })()}
-  </div>
-
-  <div className="text-base text-gray-600 mb-2">선택 정보</div>
-  <div className="text-base font-medium mb-4">{selectedDate} {selectedTime}</div>
-  <div className="text-lg font-bold text-blue-600 mb-6">{price}</div>
-  
-  {/* 예매 버튼 또는 예정 안내 */}
-  {isBeforeOpen ? (
-    <div className="w-full text-center text-base text-gray-500 py-4 bg-gray-100 rounded-md">
-      {renderOpenDate()}
+      )}
     </div>
-  ) : (
-    <button
-      className="w-full bg-blue-600 text-white rounded-md py-4 font-semibold text-base hover:bg-blue-700 disabled:bg-gray-300 cursor-pointer"
-      onClick={onReservation}
-      disabled={!selectedTime}
-    >
-      예약하기
-    </button>
-  )}
-</div>
-
   );
 };
 

--- a/frontend/src/app/concert/[slug]/components/ConcertInfoTabs.tsx
+++ b/frontend/src/app/concert/[slug]/components/ConcertInfoTabs.tsx
@@ -73,8 +73,6 @@ const ConcertInfoTabs: React.FC<ConcertInfoTabsProps> = ({
                   <td className="p-4">
                     {concert.booking_fee ? `장당 ${concert.booking_fee.toLocaleString()}원` : '없음'}
                   </td>
-                  <th className="bg-gray-50 p-4 font-semibold">배송료</th>
-                  <td className="p-4">현장수령 무료, 배송 3,200원</td>
                 </tr>
                 <tr>
                   <th className="bg-gray-50 p-4 font-semibold">유효기간/이용조건</th>

--- a/frontend/src/app/modal/OneTicketModal.tsx
+++ b/frontend/src/app/modal/OneTicketModal.tsx
@@ -3,10 +3,11 @@ import { IoClose } from 'react-icons/io5';
 import { motion, AnimatePresence } from 'framer-motion';
 
 interface OneTicketModalProps {
+  isDuplicate?: boolean;
   onClose: () => void;
 }
 
-const OneTicketModal: React.FC<OneTicketModalProps> = ({ onClose }) => {
+const OneTicketModal: React.FC<OneTicketModalProps> = ({ isDuplicate = false, onClose }) => {
   const [highlight, setHighlight] = useState(false);
 
   const handleBackdropClick = () => {
@@ -45,16 +46,26 @@ const OneTicketModal: React.FC<OneTicketModalProps> = ({ onClose }) => {
           {/* X 버튼 */}
           <button
             onClick={onClose}
-            className="absolute top-5 right-5 text-gray-500 hover:text-gray-700 text-2xl"
+            className="absolute top-5 right-5 text-gray-500 hover:text-gray-700 text-2xl cursor-pointer"
           >
             <IoClose />
           </button>
 
           {/* 내용 */}
-          <h3 className="text-2xl font-bold mb-6 text-center">알림</h3>
+          <h3 className="text-2xl font-bold mb-6 text-center">
+            알림
+          </h3>
           <p className="text-base text-gray-700 text-center leading-relaxed">
-            해당 콘서트는{' '}
-            <span className="text-red-500 font-bold">1인 1매</span>만 예매 가능합니다.
+            {isDuplicate ? (
+              <>
+                해당 콘서트는 <span className="text-red-500 font-bold">이미 예매</span>하셨습니다. <br />
+                중복 예매는 <span className="text-red-500 font-bold">불가능</span>합니다.
+              </>
+            ) : (
+              <>
+                해당 콘서트는 <span className="text-red-500 font-bold">1인 1매</span>만 예매 가능합니다.
+              </>
+            )}
           </p>
         </motion.div>
       </motion.div>

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,3 +1,6 @@
+import { TicketMintResult } from '../types/ticket';
+import { UserTicket } from '@/types/ticket';
+
 import { 
   SignupRequest, 
   LoginRequest, 
@@ -96,6 +99,19 @@ class ApiClient {
       },
     });
   }
+// 사용자 티켓 목록 조회 (userId 기반)
+async getUserTickets(userId: string): Promise<ApiResponse<{ tickets: UserTicket[] }>> {
+  return this.request<{ tickets: UserTicket[] }>(`/users/tickets/${userId}`, {
+    method: 'GET',
+  });
+}
+
+// 블록체인 민팅 티켓 조회 (NFT 티켓 목록용)
+async getMintedTickets(userId: string): Promise<ApiResponse<TicketMintResult[]>> {
+  return this.request(`/tickets/minted/${userId}`, {
+    method: 'GET',
+  });
+}
 
   // 사용자 정보 업데이트
   async updateUser(userData: { name: string; resident_number: string }): Promise<ApiResponse<{ success: boolean }>> {

--- a/frontend/src/types/ticket.ts
+++ b/frontend/src/types/ticket.ts
@@ -1,10 +1,11 @@
-//블록체인 티켓 민팅 결과
+// 블록체인 티켓 민팅 결과 (이것은 블록체인 응답에만 사용)
 export interface TicketMintResult {
   token_id: string;
   tx_hash: string;
   metadata_uri: string;
   seat_number: string;
 }
+
 // NFT 메타데이터 구조 정의
 export interface TicketMetadata {
   name: string;
@@ -16,10 +17,33 @@ export interface TicketMetadata {
   }>;
 }
 
-// 전체 티켓 정보 
-export interface TicketInfo {
-  tokenId: string;
-  ticketId: string;
-  metadata: TicketMetadata;
+// 전체 티켓 정보 (API로부터 받는 원본 티켓 정보)
+export interface UserTicket {
+  id: string;
+  concert: {
+    id: string;
+    title: string;
+    start_date: string;
+  };
+  seat: {
+    section: string;
+    row: string;
+    number: string;
+  };
   price: number;
+  status: 'active' | 'canceled';
+}
+
+// Navbar와 RecentNFTTickets에서 사용할 "표시용" 티켓 정보 타입
+
+export interface TicketInfo {
+  tokenId: string; 
+  ticketId: string; 
+  metadata: TicketMetadata; 
+  price: number; 
+  concert: { 
+    id: string;
+    title: string;
+    start_date: string;
+  };
 }


### PR DESCRIPTION
Feat: 'sold', 'hold'인 구역 회색으로 변경, 선택 불가능으로 수정
→ 예매 완료(sold) 및 홀드(hold) 상태 좌석을 시각적으로 회색 처리하여 구분하고, 선택이 불가능하도록 기능을 추가


Design: 배송비 정적으로 사용한거 삭제
→ 불필요하게 하드코딩되어 있던 배송비 값을 제거

Feat: 블록체인 민팅 티켓조회와 사용자 티켓 목록 조회 구별
→ 블록체인에서 발행된 티켓 민팅 정보와 일반 사용자 예매 정보(UserTicket)를 별도로 구분하여 API 호출 및 타입 정의


Feat: 중복 예매 처리 방지로 모달창 구현 및 버튼 비활성화 추가
→ 동일 콘서트에 대해 중복 예매가 불가능하도록 하고, 이미 예매한 경우에는 안내 모달을 띄우고 예약 버튼을 비활성화