### PR TITLE
FEAT: 관리자 주소 조회 기능 개선

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1157,4 +1157,34 @@ router.post('/validate-email', async (req: Request, res: Response<ApiResponse>) 
   }
 });
 
+/**
+ * 관리자 주소 조회
+ * GET /auth/admin-address
+ */
+router.get('/admin-address', async (req: Request, res: Response<ApiResponse>) => {
+  try {
+    const adminAddress = process.env.ADMIN_ADDRESS;
+    
+    if (!adminAddress) {
+      return res.status(500).json({
+        success: false,
+        error: '관리자 주소가 설정되지 않았습니다.'
+      });
+    }
+
+    res.json({
+      success: true,
+      data: {
+        adminAddress
+      }
+    });
+  } catch (error) {
+    console.error('관리자 주소 조회 오류:', error);
+    res.status(500).json({
+      success: false,
+      error: '관리자 주소 조회 중 오류가 발생했습니다.'
+    });
+  }
+});
+
 export default router; 

--- a/frontend/src/app/components/AuthGuard.tsx
+++ b/frontend/src/app/components/AuthGuard.tsx
@@ -52,12 +52,32 @@ export default function AuthGuard({ children, adminOnly = false }: AuthGuardProp
         if (userData.success && userData.data?.user) {
           const isLoggedIn = true;
           
-          // 관리자 권한 확인
-          const adminAddress = '0x030fd25c452078627Db888f8B22aF1c0fEcDCf97';
-          const userWalletAddress = userData.data.user.walletAddress;
-          const isAdmin = userWalletAddress?.toLowerCase() === adminAddress.toLowerCase();
-          
-          setAuthState({ isLoggedIn, isAdmin, loading: false });
+          // 관리자 주소를 백엔드에서 가져오기
+          try {
+            const adminResponse = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/admin-address`);
+            let adminAddress = '0xcf317Ec96aC41442dCb8a5f03196C00736C1f2d9'; // 기본값
+            
+            if (adminResponse.ok) {
+              const adminData = await adminResponse.json();
+              if (adminData.success && adminData.data?.adminAddress) {
+                adminAddress = adminData.data.adminAddress;
+              }
+            }
+            
+            // 관리자 권한 확인
+            const userWalletAddress = userData.data.user.walletAddress;
+            const isAdmin = userWalletAddress?.toLowerCase() === adminAddress.toLowerCase();
+            
+            setAuthState({ isLoggedIn, isAdmin, loading: false });
+          } catch (error) {
+            console.error('관리자 주소 조회 실패:', error);
+            // 기본값으로 관리자 권한 확인
+            const adminAddress = '0xcf317Ec96aC41442dCb8a5f03196C00736C1f2d9';
+            const userWalletAddress = userData.data.user.walletAddress;
+            const isAdmin = userWalletAddress?.toLowerCase() === adminAddress.toLowerCase();
+            
+            setAuthState({ isLoggedIn, isAdmin, loading: false });
+          }
         } else {
           setAuthState({ isLoggedIn: false, isAdmin: false, loading: false });
         }


### PR DESCRIPTION
- 백엔드에 /auth/admin-address API 엔드포인트 추가
- 프론트엔드 AuthGuard에서 하드코딩된 관리자 주소 제거
- 백엔드 환경변수 ADMIN_ADDRESS를 동적으로 조회하도록 수정
- API 호출 실패 시 기본값으로 fallback 처리

테스트 URL:
- 관리자 주소 API: https://tickity-api.jp.ngrok.io/auth/admin-address
- 콘서트 관리: https://tickity.ngrok.io/admin/concerts
- 콘서트 등록: https://tickity.ngrok.io/admin/concert-create