### PR TITLE
feat: 실시간 얼굴 인증으로 교체 등록 로직 변경

### DIFF
--- a/ai-server/config.py
+++ b/ai-server/config.py
@@ -10,5 +10,5 @@ supabase = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
 REGISTERED_FACE_DIR = os.path.join(os.getcwd(), "data", "registered_faces")
 THRESHOLD = 0.5
-
+L2_THRESHOLD = 1.2 
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 import os
 from config import FRONTEND_URL
 from routers import face
+from fastapi.staticfiles import StaticFiles
 
 app = FastAPI()
 
@@ -26,3 +27,4 @@ app.add_middleware(
 
 # Face API 라우터 등록
 app.include_router(face.router, prefix="/face", tags=["Face API"])
+app.mount("/static", StaticFiles(directory="static"), name="static")

--- a/ai-server/routers/face.py
+++ b/ai-server/routers/face.py
@@ -1,13 +1,42 @@
 from fastapi import APIRouter, UploadFile, File, Form, Request
 from fastapi.responses import JSONResponse
 from services.face_service import fetch_registered_embeddings, register_user_face_db, verify_user_identity, register_user_face
-from utils.io_utils import extract_embedding_from_video_optimized
+from utils.io_utils import extract_embedding_from_image
 from uuid import uuid4
 from utils.similarity import cosine_similarity
 from config import THRESHOLD
+import numpy as np
+import hashlib
 
 router = APIRouter()
 embedding_store = {}
+embedding_cache = {}
+
+
+@router.post("/load-user-embedding")
+async def load_user_embedding(target_user_id: str = Form(...)):
+    """
+    특정 사용자의 embedding을 DB에서 조회해 embedding_cache에 저장
+    """
+    from services.face_service import validate_uuid_or_test_id
+    from config import supabase
+    from utils.crypto_utils import decrypt_embedding
+
+    try:
+        validated_user_id = validate_uuid_or_test_id(target_user_id)
+        response = supabase.table("face_embeddings").select("embedding_enc").eq("user_id", validated_user_id).execute()
+        
+        if not response.data:
+            return {"success": False, "error": "등록된 얼굴 정보가 없습니다."}
+        
+        db_embedding = decrypt_embedding(response.data[0]['embedding_enc'])
+        embedding_cache[validated_user_id] = db_embedding
+
+        print(f"✅ {validated_user_id} embedding 캐시에 저장 완료")
+        return {"success": True, "message": "embedding 캐시에 저장 완료"}
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
 
 @router.post("/register")
 async def register_face_to_db(
@@ -26,70 +55,54 @@ async def verify_frame(
     target_user_id: str = Form(...)
 ):
     """
-    특정 사용자의 얼굴 인증 - 대상 사용자 ID와 비교
+    특정 사용자의 얼굴 인증 - embedding_cache에 저장된 대상 사용자 ID의 embedding과 비교
     """
     frame_bytes = await frame.read()
-    # 비디오 파일이므로 extract_embedding_from_video_optimized 사용
-    embedding = extract_embedding_from_video_optimized(frame_bytes)
+    embedding = extract_embedding_from_image(frame_bytes)
     if embedding is None:
         return {"success": False, "verified": False, "error": "얼굴을 감지하지 못했습니다."}
 
-    # 특정 사용자의 임베딩만 가져오기
-    from services.face_service import validate_uuid_or_test_id
-    try:
-        validated_user_id = validate_uuid_or_test_id(target_user_id)
-    except:
-        return {"success": False, "verified": False, "error": "유효하지 않은 사용자 ID입니다."}
+    # ✅ 캐시에서 embedding 가져오기
+    db_embedding = embedding_cache.get(target_user_id)
+    if db_embedding is None:
+        return {"success": False, "verified": False, "error": "embedding_cache에 해당 사용자의 embedding이 없습니다. /load-user-embedding 먼저 호출하세요."}
 
-    # 실제 Supabase 데이터만 사용 - 더미 테스트 제거
-    from config import supabase
-    from utils.crypto_utils import decrypt_embedding
-    import hashlib
-    
-    try:
-        response = supabase.table("face_embeddings").select("embedding_enc").eq("user_id", validated_user_id).execute()
-        if not response.data:
-            return {"success": False, "verified": False, "error": "등록된 얼굴 정보가 없습니다."}
-        
-        # 임베딩 복호화
-        db_embedding = decrypt_embedding(response.data[0]['embedding_enc'])
-        
-        # 유사도 계산
+    # ✅ 유사도 계산
+    if db_embedding.ndim == 2:
+        scores = [cosine_similarity(embedding, emb) for emb in db_embedding]
+        score = max(scores)
+    else:
         score = cosine_similarity(embedding, db_embedding)
-        verified = score > THRESHOLD
-        
-        print(f"🔍 얼굴 인증 결과:")
-        print(f"  - 사용자 ID: {validated_user_id}")
-        print(f"  - 유사도 점수: {score:.4f}")
-        print(f"  - 임계값: {THRESHOLD}")
-        print(f"  - 인증 결과: {'성공' if verified else '실패'}")
-        
-        # 얼굴 해시 생성 (인증 성공 시에만)
-        face_hash = None
-        if verified:
-            # 현재 인증된 임베딩을 기반으로 해시 생성
-            embedding_str = ','.join([f"{x:.6f}" for x in embedding.flatten()])
-            face_hash = hashlib.sha256(embedding_str.encode()).hexdigest()
-            face_hash = f"0x{face_hash}"
-            print(f"  - 생성된 얼굴 해시: {face_hash}")
-        
-        result = {
-            "success": True,
-            "verified": bool(verified),  # numpy.bool을 Python bool로 변환
-            "user_id": validated_user_id if verified else "Unknown",
-            "score": float(score),
-            "threshold": float(THRESHOLD),
-            "message": f"유사도 {score:.4f} (임계값: {THRESHOLD})"
-        }
-        
-        # 인증 성공 시 얼굴 해시 추가
-        if verified and face_hash:
-            result["face_hash"] = face_hash
-        
-        return result
-        
-    except Exception as e:
-        return {"success": False, "verified": False, "error": f"인증 처리 중 오류: {str(e)}"}
+
+    verified = score > THRESHOLD
+
+    print(f"🔍 얼굴 인증 결과:")
+    print(f"  - 사용자 ID: {target_user_id}")
+    print(f"  - 유사도 점수: {score:.4f}")
+    print(f"  - 임계값: {THRESHOLD}")
+    print(f"  - 인증 결과: {'성공' if verified else '실패'}")
+
+    # ✅ 얼굴 해시 생성 (인증 성공 시)
+    face_hash = None
+    if verified:
+        embedding_str = ','.join([f"{x:.6f}" for x in embedding.flatten()])
+        face_hash = hashlib.sha256(embedding_str.encode()).hexdigest()
+        face_hash = f"0x{face_hash}"
+        print(f"  - 생성된 얼굴 해시: {face_hash}")
+
+    result = {
+        "success": True,
+        "verified": bool(verified),
+        "user_id": target_user_id if verified else "Unknown",
+        "score": float(score),
+        "threshold": float(THRESHOLD),
+        "message": f"유사도 {score:.4f} (임계값: {THRESHOLD})"
+    }
+
+    if verified and face_hash:
+        result["face_hash"] = face_hash
+
+    return result
 
 @router.post("/verify-general")
 async def verify_general(frame: UploadFile = File(...)):
@@ -97,8 +110,8 @@ async def verify_general(frame: UploadFile = File(...)):
     일반 얼굴 인증 - 전체 DB에서 최고 유사도 찾기 (개선된 함수 사용)
     """
     frame_bytes = await frame.read()
-    # 개선된 함수 사용으로 일관성 확보
-    embedding = extract_embedding_from_video_optimized(frame_bytes)
+    # ✅ 실시간 프레임(image/jpeg) 처리에 맞게 수정
+    embedding = extract_embedding_from_image(frame_bytes)
     if embedding is None:
         return {"success": False, "user_id": "Unknown", "score": 0.0}
 

--- a/ai-server/static/test.html
+++ b/ai-server/static/test.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <title>실시간 얼굴 인증 테스트</title>
+</head>
+
+<body>
+  <h1>실시간 얼굴 인증 테스트 (/verify-frame)</h1>
+
+  <video id="video" width="320" height="240" autoplay></video>
+  <p id="status"></p>
+
+  <script>
+    const video = document.getElementById("video");
+    const status = document.getElementById("status");
+    const targetUserId = "c2440e95-0434-413a-8577-ed3b81b1b7d4"; // ✅ 실제 user_id
+
+    // ✅ load-user-embedding 호출
+    async function loadUserEmbedding() {
+      const formData = new FormData();
+      formData.append("target_user_id", targetUserId);
+
+      const res = await fetch("http://localhost:8000/face/load-user-embedding", {
+        method: "POST",
+        body: formData
+      });
+      const data = await res.json();
+      console.log("🔄 load-user-embedding 결과:", data);
+    }
+
+    // ✅ 카메라 스트림 시작
+    navigator.mediaDevices.getUserMedia({ video: true })
+      .then(stream => {
+        video.srcObject = stream;
+      })
+      .catch(err => {
+        console.error("카메라 오류:", err);
+        alert("카메라 접근 불가");
+      });
+
+    // ✅ 1초마다 캡처 후 POST 요청
+    async function verifyLoop() {
+      while (true) {
+        const canvas = document.createElement("canvas");
+        canvas.width = video.videoWidth || 320;
+        canvas.height = video.videoHeight || 240;
+        const ctx = canvas.getContext("2d");
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+        const blob = await new Promise(resolve => canvas.toBlob(resolve, "image/jpeg"));
+
+        const formData = new FormData();
+        formData.append("frame", blob, "frame.jpg");
+        formData.append("target_user_id", targetUserId);
+
+        try {
+          status.innerText = "🔄 인증 요청 중...";
+          const res = await fetch("http://localhost:8000/face/verify-frame", {
+            method: "POST",
+            body: formData
+          });
+          const data = await res.json();
+          console.log(data);
+
+          if (data.success) {
+            status.innerText = data.verified
+              ? `✅ 인증 성공\n유사도: ${data.score.toFixed(4)}`
+              : `❌ 인증 실패\n유사도: ${data.score.toFixed(4)}`;
+          } else {
+            status.innerText = `⚠️ 오류: ${data.error || '알 수 없는 오류'}`;
+          }
+
+        } catch (err) {
+          console.error("요청 오류:", err);
+          status.innerText = "❌ 인증 요청 실패";
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+
+    // ✅ embedding load 후 루프 시작
+    video.addEventListener("loadedmetadata", async () => {
+      await loadUserEmbedding();
+      verifyLoop();
+    });
+  </script>
+
+</body>
+</html>

--- a/ai-server/utils/crypto_utils.py
+++ b/ai-server/utils/crypto_utils.py
@@ -9,12 +9,39 @@ if not ENCRYPTION_KEY:
 
 fernet = Fernet(ENCRYPTION_KEY)
 
-def encrypt_embedding(embedding: np.ndarray) -> str:
-    bytes_data = embedding.astype(np.float32).tobytes()
-    encrypted = fernet.encrypt(bytes_data)
+def encrypt_embedding(embeddings: np.ndarray) -> str:
+    embeddings = np.array(embeddings, dtype=np.float32)
+    
+    # 항상 2D shape 저장
+    if embeddings.ndim == 1:
+        embeddings = embeddings.reshape(1, -1)
+
+    shape = np.array(embeddings.shape, dtype=np.int32)
+    shape_bytes = shape.tobytes()
+    data_bytes = embeddings.tobytes()
+    combined = shape_bytes + data_bytes
+
+    encrypted = fernet.encrypt(combined)
     return base64.b64encode(encrypted).decode()
 
 def decrypt_embedding(encrypted_b64: str) -> np.ndarray:
     encrypted = base64.b64decode(encrypted_b64.encode())
     decrypted = fernet.decrypt(encrypted)
-    return np.frombuffer(decrypted, dtype=np.float32)
+
+    shape = np.frombuffer(decrypted[:8], dtype=np.int32)
+    print(f"🔍 복호화된 shape 정보: {shape}")
+
+    data = decrypted[8:]
+    embeddings = np.frombuffer(data, dtype=np.float32)
+
+    print(f"🔍 복호화된 embedding 길이: {len(embeddings)}")
+
+    try:
+        embeddings = embeddings.reshape(shape)
+    except Exception as e:
+        print(f"❌ reshape 실패: {e}, shape={shape}, data_len={len(embeddings)}")
+        raise e
+
+    if embeddings.shape[0] == 1:
+        embeddings = embeddings[0]
+    return embeddings

--- a/ai-server/utils/similarity.py
+++ b/ai-server/utils/similarity.py
@@ -1,4 +1,20 @@
 import numpy as np
 
 def cosine_similarity(a, b):
+    """
+    코사인 유사도 계산
+    """
     return np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))
+
+def compare_embeddings(a, b, threshold_cosine=0.5):
+    """
+    코사인 유사도만 비교하여 결과를 반환
+    - threshold_cosine: 인증 성공을 위한 최소 코사인 유사도
+    """
+    cos_sim = cosine_similarity(a, b)
+    verified = cos_sim > threshold_cosine
+
+    return {
+        "cosine_similarity": cos_sim,
+        "verified": verified
+    }

--- a/ai-server/verify_live.py
+++ b/ai-server/verify_live.py
@@ -6,37 +6,55 @@ from insightface.app import FaceAnalysis
 
 # ✅ 현재 파일 기준으로 루트 디렉토리를 sys.path에 등록
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
-from utils.similarity import cosine_similarity
 
+from config import supabase
+from utils.crypto_utils import decrypt_embedding
+from utils.similarity import cosine_similarity, l2_distance
+
+# 🔧 Threshold 설정
 THRESHOLD = 0.5
-SAVE_DIR = "./data/registered_faces"
+L2_THRESHOLD = 1.2
 
-# 모델 준비
+# ✅ 모델 준비
 app = FaceAnalysis(name="buffalo_l", providers=['CPUExecutionProvider'])
 app.prepare(ctx_id=0, det_size=(320, 320))
 
-# 등록된 얼굴 임베딩 로드
-def load_registered_embeddings():
-    db = {}
-    for file in os.listdir(SAVE_DIR):
-        if file.endswith(".npy"):
-            name = file.replace(".npy", "")
-            vec = np.load(os.path.join(SAVE_DIR, file))
-            db[name] = vec
-    return db
+# ✅ 특정 user_id만 테스트
+TARGET_USER_ID = "c2440e95-0434-413a-8577-ed3b81b1b7d4"  # 🔴 테스트할 user_id로 수정
 
+def load_registered_embeddings():
+    print("🔄 Supabase에서 등록된 embedding 로딩 중...")
+    try:
+        response = supabase.table("face_embeddings").select("user_id, embedding_enc").execute()
+        embeddings = {}
+        for record in response.data:
+            user_id = record['user_id'].strip()  # 혹시 모를 공백 제거
+            embedding_enc = record['embedding_enc']
+            emb = decrypt_embedding(embedding_enc)  # (5,512) or (512,)
+            embeddings[user_id] = emb
+        print(f"✅ {len(embeddings)}명의 임베딩 로드 완료")
+        return embeddings
+    except Exception as e:
+        print(f"❌ Supabase 조회 실패: {e}")
+        return {}
+
+# ✅ 등록된 embedding 로드
 db_embeddings = load_registered_embeddings()
-if not db_embeddings:
-    print("❌ 등록된 사용자가 없습니다. 먼저 얼굴을 등록하세요.")
+print("🔎 등록된 user_ids:", list(db_embeddings.keys()))  # 디버깅용
+
+if TARGET_USER_ID not in db_embeddings:
+    print(f"❌ {TARGET_USER_ID} 사용자가 등록되어 있지 않습니다.")
     exit(1)
 
-# ✅ 고정된 카메라 인덱스 사용 (video0)
+target_embedding = db_embeddings[TARGET_USER_ID]
+
+# ✅ 카메라 초기화
 cap = cv2.VideoCapture(0)
 if not cap.isOpened():
     print("❌ 웹캠을 열 수 없습니다.")
     exit(1)
 
-print("🎥 실시간 얼굴 인증 시작 (ESC: 종료)")
+print(f"🎥 실시간 얼굴 인증 시작 (ESC: 종료) - 대상 사용자: {TARGET_USER_ID}")
 
 while True:
     ret, frame = cap.read()
@@ -51,17 +69,21 @@ while True:
         bbox = face.bbox.astype(int)
         live_emb = face.embedding
 
-        best_match = "Unknown"
-        best_score = -1
+        # ✅ 다중 embedding 비교
+        if target_embedding.ndim == 2:
+            scores = [cosine_similarity(live_emb, emb) for emb in target_embedding]
+            distances = [l2_distance(live_emb, emb) for emb in target_embedding]
+            score = max(scores)
+            distance = distances[np.argmax(scores)]
+        else:
+            score = cosine_similarity(live_emb, target_embedding)
+            distance = l2_distance(live_emb, target_embedding)
 
-        for name, reg_emb in db_embeddings.items():
-            score = cosine_similarity(live_emb, reg_emb)
-            if score > best_score:
-                best_score = score
-                best_match = name if score > THRESHOLD else "Unknown"
+        verified = score > THRESHOLD and distance < L2_THRESHOLD
+
+        label = f"{'✅' if verified else '❌'} {TARGET_USER_ID} ({score:.2f}, L2:{distance:.2f})"
 
         cv2.rectangle(display_frame, tuple(bbox[:2]), tuple(bbox[2:]), (0, 255, 0), 2)
-        label = f"{best_match} ({best_score:.2f})"
         cv2.putText(display_frame, label, (bbox[0], bbox[1] - 10),
                     cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 255, 255), 2)
 

--- a/ai-server/verify_live_supabase.py
+++ b/ai-server/verify_live_supabase.py
@@ -77,14 +77,21 @@ def main():
 
             # ✅ DB embedding과 유사도 비교 (복호화된 임베딩 사용)
             for user_id, reg_emb in db_embeddings.items():
-                score = cosine_similarity(live_emb, reg_emb)
+                if reg_emb.ndim == 2:
+                    # 다중 embedding (5,512)
+                    scores = [cosine_similarity(live_emb, emb) for emb in reg_emb]
+                    score = max(scores)
+                else:
+                    score = cosine_similarity(live_emb, reg_emb)
+
+                # ✅ threshold 비교
                 if score > best_score:
                     best_score = score
                     best_match = user_id if score > THRESHOLD else "Unknown"
 
             # ✅ 결과 화면에 표시
-            cv2.rectangle(display_frame, tuple(bbox[:2]), tuple(bbox[2:]), (0, 255, 0), 2)
             label = f"{best_match} ({best_score:.2f})"
+            cv2.rectangle(display_frame, tuple(bbox[:2]), tuple(bbox[2:]), (0, 255, 0), 2)
             cv2.putText(display_frame, label, (bbox[0], bbox[1] - 10),
                         cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 255, 255), 2)
 

--- a/frontend/src/app/face-registration/page.tsx
+++ b/frontend/src/app/face-registration/page.tsx
@@ -111,9 +111,9 @@ export default function FaceRegistrationPage() {
     timerRef.current = setInterval(() => {
       setRecordingTime(prev => {
         const newTime = prev + 1;
-        if (newTime >= 3) {
+        if (newTime >= 6) {
           mediaRecorder.stop();
-          return 3;
+          return 6;
         }
         return newTime;
       });
@@ -193,9 +193,9 @@ export default function FaceRegistrationPage() {
             <h3 className="font-bold">사용 방법</h3>
             <ul className="mt-2 list-disc list-inside text-sm">
               <li>얼굴이 화면 중앙에 잘 보이도록 위치하세요</li>
-              <li>녹화 버튼을 눌러 3초간 비디오를 촬영하세요 (자동 중지)</li>
+              <li>녹화 버튼을 눌러 6초간 비디오를 촬영하세요 (자동 중지)</li>
               <li>자동으로 얼굴 정보가 등록됩니다</li>
-              <li><strong>AI가 3초 동안 여러 프레임을 분석해 최적의 얼굴 데이터를 생성합니다</strong></li>
+              <li><strong>AI가 6초 동안 여러 프레임을 분석해 최적의 얼굴 데이터를 생성합니다</strong></li>
             </ul>
           </div>
 
@@ -229,7 +229,7 @@ export default function FaceRegistrationPage() {
                 </div>
                 {/* 타이머 */}
                 <div className="absolute top-2 right-2 bg-black bg-opacity-50 text-white px-2 py-1 rounded">
-                  <span className="font-bold">{recordingTime}/3초</span>
+                  <span className="font-bold">{recordingTime}/6초</span>
                 </div>
                 {/* 가이드 테두리 */}
                 <div className="absolute inset-2 border-2 border-green-400 rounded-lg pointer-events-none"></div>
@@ -267,7 +267,7 @@ export default function FaceRegistrationPage() {
                 disabled={!cameraReady}
                 className="bg-blue-500 text-white px-8 py-3 rounded-lg hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {cameraReady ? '3초 녹화 시작' : '카메라 준비 중...'}
+                {cameraReady ? '6초 녹화 시작' : '카메라 준비 중...'}
               </button>
             ) : isRegistering ? (
               <div className="flex items-center justify-center">


### PR DESCRIPTION
### 🔥 주요 변경 사항
- 기존 얼굴 인증 방식을 **실시간 얼굴 인증**으로 교체
- **embedding preload** 로직 추가
  - /load-user-embedding 호출 후 캐시 저장
- /verify-frame API 수정
  - DB 조회 제거 → 캐싱 기반 비교
- FaceVerificationComponent.tsx 수정
  - 카메라 onloadedmetadata에서 embedding preload 후 루프 시작
  - IIFE async-await 패턴 적용
  - 인증 성공 시 onSuccess(face_hash) 호출 구조 유지
