### PR TITLE
FIX: QR 스캔 토큰 충돌 및 nonce 오류 해결

### DIFF
--- a/backend/src/tickets/tickets.service.ts
+++ b/backend/src/tickets/tickets.service.ts
@@ -917,6 +917,8 @@ export const verifyQRCode = async (qrDataString: string): Promise<{
     const { BlockchainVerificationService } = await import('../blockchain/verification.service');
     const blockchainVerification = new BlockchainVerificationService();
     
+    console.log('🔍 QR 검증 시작:', { tokenId, ticketId, walletAddress });
+    
     // 🎯 블록체인 중심 검증 (QR에서 추출한 지갑 주소 사용)
     const [ownershipResult, usageResult, faceResult, cancellationResult] = await Promise.all([
       // 소유권 검증: 블록체인 소유자 vs QR 지갑 주소


### PR DESCRIPTION
npx hardhat node --reset

npx clean전에 위 명령어먼저실행하기 

- 토큰 ID 생성 범위를 9e15 ~ 1e16-1로 변경하여 기존 토큰과 충돌 방지
- markAsUsed 함수에서 nonce 명시적 관리로 동시 트랜잭션 오류 해결
- 'QR 스캔 시 이미 사용된 티켓' 문제 완전 해결