### PR TITLE
FIX : 마이페이지에서 티켓 취소 시 콘서트 상세 막힘 해결

### DIFF
--- a/frontend/src/app/concert/[slug]/page.tsx
+++ b/frontend/src/app/concert/[slug]/page.tsx
@@ -55,9 +55,9 @@ const ConcertDetail = () => {
         const res = await apiClient.getUserTickets(userId);
         const tickets: UserTicket[] = res.data?.tickets ?? [];
 
-        const hasTicketForConcert = tickets.some(
-          (ticket) => ticket.concert?.id === concert.id
-        );
+const hasTicketForConcert = tickets.some(
+  (ticket) => ticket.concert?.id === concert.id && !ticket.is_cancelled
+);
 
         if (hasTicketForConcert) {
           setIsDuplicateBooking(true);

--- a/frontend/src/app/modal/ConfirmModal.tsx
+++ b/frontend/src/app/modal/ConfirmModal.tsx
@@ -1,34 +1,55 @@
 'use client';
 
 import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 
 interface ConfirmModalProps {
-  message: string;
+  message: React.ReactNode;
   onConfirm: () => void;
   onCancel: () => void;
 }
 
 const ConfirmModal: React.FC<ConfirmModalProps> = ({ message, onConfirm, onCancel }) => {
   return (
-    <div className="fixed inset-0 bg-opacity-40 flex items-center justify-center z-50">
-      <div className="bg-white p-6 rounded-lg shadow-lg max-w-md w-full border border-gray-300 focus-within:text-blue-500">
-        <p className="text-sm mb-4">{message}</p>
-        <div className="flex justify-end gap-3">
-          <button
-            className="px-4 py-1 text-sm bg-gray-200 rounded hover:bg-gray-300 cursor-pointer"
-            onClick={onCancel}
-          >
-            취소
-          </button>
-          <button
-            className="px-4 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer"
-            onClick={onConfirm}
-          >
-            확인
-          </button>
+    <AnimatePresence>
+      <motion.div
+        key="backdrop"
+        className="fixed inset-0 bg-black bg-opacity-30 z-40"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.2 }}
+        onClick={onCancel}
+      />
+
+      <motion.div
+        key="modal"
+        className="fixed z-50 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-auto"
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        exit={{ opacity: 0, scale: 0.95 }}
+        transition={{ duration: 0.25, ease: 'easeOut' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="bg-white p-6 rounded-lg shadow-lg max-w-md w-full border border-gray-300 cursor-pointer">
+          <div className="text-sm mb-4">{message}</div>
+          <div className="flex justify-end gap-3">
+            <button
+              className="px-4 py-1 text-sm bg-gray-200 rounded hover:bg-gray-300"
+              onClick={onCancel}
+            >
+              취소
+            </button>
+            <button
+              className="px-4 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer"
+              onClick={onConfirm}
+            >
+              확인
+            </button>
+          </div>
         </div>
-      </div>
-    </div>
+      </motion.div>
+    </AnimatePresence>
   );
 };
 

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -106,6 +106,13 @@ async getUserTickets(userId: string): Promise<ApiResponse<{ tickets: UserTicket[
   });
 }
 
+// 사용자 대시보드 조회
+async getUserDashboard(userId: string): Promise<ApiResponse<any>> {
+  return this.request<any>(`/users/dashboard/${userId}`, {
+    method: 'GET',
+  });
+}
+
 // 블록체인 민팅 티켓 조회 (NFT 티켓 목록용)
 async getMintedTickets(userId: string): Promise<ApiResponse<TicketMintResult[]>> {
   return this.request(`/tickets/minted/${userId}`, {

--- a/frontend/src/types/ticket.ts
+++ b/frontend/src/types/ticket.ts
@@ -31,6 +31,7 @@ export interface UserTicket {
     number: string;
   };
   price: number;
+  is_cancelled?: boolean;
   status: 'active' | 'canceled';
 }
 


### PR DESCRIPTION
마이페이지에서 티켓 취소 시 콘서트 상세에서 이미 구매한 콘서트라는 예외처리 수정, 
취소버튼 클릭시 모달창 생성,
마이페이지에서 api를 apiClient.ts로 옮겨 유사한 API 호출 함수들을 하나로 통합하여 중복 코드를 제거,
모달창 디자인 수정 + 애니메이션 효과