### PR TITLE
FEAT: AI 얼굴등록 → 백엔드 API 연동 및 회원정보 입력 강제

### DIFF
--- a/frontend/src/app/face-registration/page.tsx
+++ b/frontend/src/app/face-registration/page.tsx
@@ -149,10 +149,11 @@ function FaceRegistrationContent() {
       console.log('✅ 얼굴 등록 응답:', result);
 
       if (response.ok && result.message) {
-        setSuccess('얼굴 등록이 완료되었습니다! 잠시 후 메인 페이지로 이동합니다.');
+        setSuccess('얼굴 등록이 완료되었습니다! 잠시 후 회원정보 입력 페이지로 이동합니다.');
         setTimeout(() => {
-          router.push('/');
-        }, 3000);
+          // 얼굴 등록 후 회원정보 입력 페이지로 이동
+          router.push(`/signup/complete?user_id=${userId}`);
+        }, 2000);
       } else {
         const errorMsg = result.error || result.detail || '얼굴 등록에 실패했습니다.';
         setError(errorMsg);


### PR DESCRIPTION
- ai-server/services/face_service.py
  - Supabase DB 직접 접근 제거, Tickity 백엔드 /auth/face-register로 POST 요청하도록 변경
  - 디버깅 로그 추가

- backend/src/auth/auth.controller.ts
  - /face-register: users에 최소 정보 insert 시 지갑 자동 생성
  - 구글 OAuth 콜백: users에 이미 있으면 email, name, wallet 등 모든 정보 update
  - 회원정보 입력(/user): accessToken으로 Supabase Auth에서 email 자동 조회 및 update, password_hash도 'google_oauth'로 강제 update

- frontend/src/app/face-registration/page.tsx
  - 얼굴 등록 성공 시 /signup/complete(회원정보 입력)로 자동 리다이렉트
  - 회원정보 입력을 반드시 거치도록 UX 개선

BREAKING: 이제 모든 가입/얼굴등록 플로우에서 email, name, resident_number, password_hash, wallet_address가 안전하게 저장됨