### PR TITLE
FIX: user_id 공백/중복 방지 및 티켓 생성 FK 사전 검증

### DIFF
--- a/backend/src/tickets/tickets.service.ts
+++ b/backend/src/tickets/tickets.service.ts
@@ -85,6 +85,16 @@ export async function createTicket(payload: {
   seat_number: string;
   price: number;
 }) {
+  // FK 사전 검증: user_id, concert_id, seat_id 모두 존재해야 함
+  const [{ data: user, error: userErr }, { data: concert, error: concertErr }, { data: seat, error: seatErr }] = await Promise.all([
+    supabase.from('users').select('id').eq('id', payload.user_id).maybeSingle(),
+    supabase.from('concerts').select('id').eq('id', payload.concert_id).maybeSingle(),
+    supabase.from('seats').select('id').eq('id', payload.seat_id).maybeSingle(),
+  ]);
+  if (userErr || !user) throw new Error('티켓 생성 실패: 유효하지 않은 사용자입니다.');
+  if (concertErr || !concert) throw new Error('티켓 생성 실패: 유효하지 않은 콘서트입니다.');
+  if (seatErr || !seat) throw new Error('티켓 생성 실패: 유효하지 않은 좌석입니다.');
+
   const { data, error } = await supabase
     .from('tickets')
     .insert({


### PR DESCRIPTION
- user_id 저장/조회 시 .trim() 적용 (auth.controller.ts)
- 얼굴 임베딩 등록 시 중복 방지 (update or insert)
- 티켓 생성 전 user_id/concert_id/seat_id FK 사전 검증 (tickets.service.ts)
- FK 불일치/없는 값이면 명확한 에러 메시지 반환

이로써 재로그인시 얼굴인증 요구단계 해결, 티켓 예매시 user_id 디비랑 일관성유지로 오류해결